### PR TITLE
added check that config file exists

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -32,6 +32,11 @@ class Config {
   public function __construct($path) {
 
     $info = pathinfo($path);
+      
+    //check that config file exists or throw exception
+    if (!file_exists($path)) {
+        throw new \Exception("Configuration file: [$path] cannot be found");
+    }
 
     // php file
     if (preg_match('@^php$@i', $info['extension'])) {


### PR DESCRIPTION
Before processing the config file in the constructor, make sure the file exists and if it does not, throw an exception.

I guess this could be done in the calling app before creating the `config` instance, but I think the config file is so fundamental to the class, that perhaps the class should check for itself.
