### PR TITLE
Remove !$temp check to fix loading an empty array

### DIFF
--- a/src/FileParser/Php.php
+++ b/src/FileParser/Php.php
@@ -44,7 +44,7 @@ class Php implements FileParserInterface
         }
 
         // Check for array, if its anything else, throw an exception
-        if (!$temp || !is_array($temp)) {
+        if (!is_array($temp)) {
             throw new UnsupportedFormatException('PHP file does not return an array');
         }
 


### PR DESCRIPTION
This loose check prevents from loading an empty array from a config file.

I'm pretty sure the only check we need here is the `is_array` check.
