### PR TITLE
Adding container-interop compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "container-interop/container-interop": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -2,6 +2,8 @@
 
 namespace Noodlehaus;
 
+use Interop\Container\ContainerInterface;
+
 /**
  * Config interface
  *
@@ -11,7 +13,7 @@ namespace Noodlehaus;
  * @link       https://github.com/noodlehaus/config
  * @license    MIT
  */
-interface ConfigInterface
+interface ConfigInterface extends ContainerInterface
 {
     /**
      * Gets a configuration setting using a simple or nested key.


### PR DESCRIPTION
Hey!

This pull request is a proposal to add "[container-interop](https://github.com/container-interop/container-interop)" compatibility to "config".
As you can see, this pull request is... wooh... 3 lines long :)

Config already complies with container-interop's `ContainerInterface`. The only thing we have to do is add the interface.

Why would we want to do that?

Container-interop is a common interface for dependency injection containers. Containers usually store services, but they can also store **parameters**. container-interop does not do any distinction between services and parameters. In container-interop vocabulary, containers are used to store "entries" (they can be either services or parameters... or whatever!)

Config could therefore be considered as a container providing config parameters. And this is absolutely great, because this means that any container compatible with container-interop (and there are a bunch of them!) would be able to fetch data from the Config container (one of the big ideas of container-interop is to allow a container to fetch parameters/service from other containers through [delegate dependency lookup](https://github.com/container-interop/container-interop/blob/master/docs/Delegate-lookup-meta.md))

In short, this pull request makes it possible to use Config really easily with a hug range of different projects.

Disclaimer: I'm one of container-interop authors, and I'm also the editor of [PSR-11](https://github.com/php-fig/fig-standards/blob/master/proposed/container.md) (with @mnapoli) that is currently in discussion and planning to transform container-interop into a PSR.
