### PR TITLE
Proposal of returning Exception if configuration key not found

### DIFF
--- a/src/AbstractConfig.php
+++ b/src/AbstractConfig.php
@@ -122,7 +122,7 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface
             return $this->get($offset);
         }
         
-        throw new \InvalidArgumentException('Configuration value not found');
+        throw new \InvalidArgumentException('Configuration key:' . $offset . 'not found');
     }
 
     /**

--- a/src/AbstractConfig.php
+++ b/src/AbstractConfig.php
@@ -117,7 +117,12 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface
      */
     public function offsetGet($offset)
     {
-        return $this->get($offset);
+        if (array_key_exists($offset, $this->data))
+        {
+            return $this->get($offset);
+        }
+        
+        throw new \InvalidArgumentException('Configuration value not found');
     }
 
     /**

--- a/src/AbstractConfig.php
+++ b/src/AbstractConfig.php
@@ -122,7 +122,7 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface
             return $this->get($offset);
         }
         
-        throw new \InvalidArgumentException('Configuration key:' . $offset . 'not found');
+        throw new \InvalidArgumentException('Configuration key: ' . $offset . ' not found');
     }
 
     /**

--- a/tests/AbstractConfigTest.php
+++ b/tests/AbstractConfigTest.php
@@ -94,20 +94,20 @@ class AbstractConfigTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers Noodlehaus\AbstractConfig::get()
-     * @expectedException InvalidArgumentException 
+     * @expectedException \InvalidArgumentException 
      */
-    public function testGetNonexistentKey()
+    public function testGetNonexistentKeyAsArray()
     {
-        return $this->config->get('proxy');
+        return $this->config['proxy'];
     }
 
     /**
      * @covers Noodlehaus\AbstractConfig::get()
-     * @expectedException InvalidArgumentException 
+     * @expectedException \InvalidArgumentException 
      */
-    public function testGetNonexistentNestedKey()
+    public function testGetNonexistentNestedKeyAsArray()
     {
-        return $this->config->get('proxy.name');
+        return $this->config['proxy'][name];
     }
 
     /**

--- a/tests/AbstractConfigTest.php
+++ b/tests/AbstractConfigTest.php
@@ -94,7 +94,7 @@ class AbstractConfigTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers Noodlehaus\AbstractConfig::get()
-     * @expectedException \InvlidArgumentException 
+     * @expectedException \InvalidArgumentException 
      */
     public function testGetNonexistentKey()
     {
@@ -103,7 +103,7 @@ class AbstractConfigTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers Noodlehaus\AbstractConfig::get()
-     * @expectedException \InvlidArgumentException 
+     * @expectedException \InvalidArgumentException 
      */
     public function testGetNonexistentNestedKey()
     {

--- a/tests/AbstractConfigTest.php
+++ b/tests/AbstractConfigTest.php
@@ -94,18 +94,20 @@ class AbstractConfigTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers Noodlehaus\AbstractConfig::get()
+     * @expectedException \InvlidArgumentException 
      */
     public function testGetNonexistentKey()
     {
-        $this->assertNull($this->config->get('proxy'));
+        return $this->config->get('proxy');
     }
 
     /**
      * @covers Noodlehaus\AbstractConfig::get()
+     * @expectedException \InvlidArgumentException 
      */
     public function testGetNonexistentNestedKey()
     {
-        $this->assertNull($this->config->get('proxy.name'));
+        return $this->config->get('proxy.name');
     }
 
     /**

--- a/tests/AbstractConfigTest.php
+++ b/tests/AbstractConfigTest.php
@@ -94,7 +94,7 @@ class AbstractConfigTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers Noodlehaus\AbstractConfig::get()
-     * @expectedException \InvalidArgumentException 
+     * @expectedException InvalidArgumentException 
      */
     public function testGetNonexistentKey()
     {
@@ -103,7 +103,7 @@ class AbstractConfigTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers Noodlehaus\AbstractConfig::get()
-     * @expectedException \InvalidArgumentException 
+     * @expectedException InvalidArgumentException 
      */
     public function testGetNonexistentNestedKey()
     {


### PR DESCRIPTION
Just made this proposal as i'm using this class on my app, but i find that if i ask for a not existent configuration key, the library returns null instead of warning that the asked configuration key is invalid. So i have to check in all app if the keys are valid..
