### PR TITLE
Implement iterator interface in AbstractConfig

### DIFF
--- a/src/AbstractConfig.php
+++ b/src/AbstractConfig.php
@@ -166,8 +166,9 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
      * Returns the data array element referenced by its internal cursor
      *
      * @return mixed The element referenced by the data array's internal cursor.
-     *     If the array is empty, the function returns false. If the array is
-     *     undefined, the function returns null
+     *     If the array is empty or there is no element at the cursor, the
+     *     function returns false. If the array is undefined, the function
+     *     returns null
      */
     public function current()
     {
@@ -178,7 +179,8 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
      * Returns the data array index referenced by its internal cursor
      *
      * @return mixed The index referenced by the data array's internal cursor.
-     *     If the array is empty or undefined, the function returns null
+     *     If the array is empty or undefined or there is no element at the
+     *     cursor, the function returns null
      */
     public function key()
     {

--- a/src/AbstractConfig.php
+++ b/src/AbstractConfig.php
@@ -3,6 +3,7 @@
 namespace Noodlehaus;
 
 use ArrayAccess;
+use Iterator;
 
 /**
  * Abstract Config class
@@ -13,7 +14,7 @@ use ArrayAccess;
  * @link       https://github.com/noodlehaus/config
  * @license    MIT
  */
-abstract class AbstractConfig implements ArrayAccess, ConfigInterface
+abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
 {
     /**
      * Stores the configuration data
@@ -155,5 +156,68 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface
     public function offsetUnset($offset)
     {
         $this->set($offset, null);
+    }
+
+    /**
+     * Iterator Methods
+     */
+
+    /**
+     * Returns the data array element referenced by its internal cursor
+     *
+     * @return mixed The element referenced by the data array's internal cursor.
+     *     If the array is empty, the function returns false. If the array is
+     *     undefined, the function returns null
+     */
+    public function current()
+    {
+        return (is_array($this->data) ? current($this->data) : null);
+    }
+
+    /**
+     * Returns the data array index referenced by its internal cursor
+     *
+     * @return mixed The index referenced by the data array's internal cursor.
+     *     If the array is empty or undefined, the function returns null
+     */
+    public function key()
+    {
+        return (is_array($this->data) ? key($this->data) : null);
+    }
+
+    /**
+     * Moves the data array's internal cursor forward one element
+     *
+     * @return mixed The element referenced by the data array's internal cursor
+     *     after the move is completed. If there are no more elements in the
+     *     array after the move, the function returns false. If the data array
+     *     is undefined, the function returns null
+     */
+    public function next()
+    {
+        return (is_array($this->data) ? next($this->data) : null);
+    }
+
+    /**
+     * Moves the data array's internal cursor to the first element
+     *
+     * @return mixed The element referenced by the data array's internal cursor
+     *     after the move is completed. If the data array is empty, the function
+     *     returns false. If the data array is undefined, the function returns
+     *     null
+     */
+    public function rewind()
+    {
+        return (is_array($this->data) ? reset($this->data) : null);
+    }
+
+    /**
+     * Tests whether the iterator's current index is valid
+     *
+     * @return bool True if the current index is valid; false otherwise
+     */
+    public function valid()
+    {
+        return (is_array($this->data) ? key($this->data) !== null : false);
     }
 }

--- a/tests/AbstractConfigTest.php
+++ b/tests/AbstractConfigTest.php
@@ -215,4 +215,128 @@ class AbstractConfigTest extends \PHPUnit_Framework_TestCase
         unset($this->config['application']);
         $this->assertNull($this->config['application']);
     }
+
+    /**
+     * @covers Noodlehaus\AbstractConfig::current()
+     */
+    public function testCurrent()
+    {
+        /* Reset to the beginning of the test config */
+        $this->config->rewind();
+        $this->assertEquals($this->config['host'], $this->config->current());
+
+        /* Step through each of the other elements of the test config */
+        $this->config->next();
+        $this->assertEquals($this->config['port'], $this->config->current());
+        $this->config->next();
+        $this->assertEquals($this->config['servers'], $this->config->current());
+        $this->config->next();
+        $this->assertEquals($this->config['application'], $this->config->current());
+
+        /* Step beyond the end and confirm the result */
+        $this->config->next();
+        $this->assertFalse($this->config->current());
+    }
+
+    /**
+     * @covers Noodlehaus\AbstractConfig::key()
+     */
+    public function testKey()
+    {
+        /* Reset to the beginning of the test config */
+        $this->config->rewind();
+        $this->assertEquals('host', $this->config->key());
+
+        /* Step through each of the other elements of the test config */
+        $this->config->next();
+        $this->assertEquals('port', $this->config->key());
+        $this->config->next();
+        $this->assertEquals('servers', $this->config->key());
+        $this->config->next();
+        $this->assertEquals('application', $this->config->key());
+
+        /* Step beyond the end and confirm the result */
+        $this->config->next();
+        $this->assertNull($this->config->key());
+    }
+
+    /**
+     * @covers Noodlehaus\AbstractConfig::next()
+     */
+    public function testNext()
+    {
+        /* Reset to the beginning of the test config */
+        $this->config->rewind();
+
+        /* Step through each of the other elements of the test config */
+        $this->assertEquals($this->config['port'], $this->config->next());
+        $this->assertEquals($this->config['servers'], $this->config->next());
+        $this->assertEquals($this->config['application'], $this->config->next());
+
+        /* Step beyond the end and confirm the result */
+        $this->assertFalse($this->config->next());
+    }
+
+    /**
+     * @covers Noodlehaus\AbstractConfig::rewind()
+     */
+    public function testRewind()
+    {
+        /* Rewind from somewhere out in the array */
+        $this->config->next();
+        $this->config->next();
+        $this->assertEquals($this->config['host'], $this->config->rewind());
+
+        /* Rewind again from the beginning of the array */
+        $this->assertEquals($this->config['host'], $this->config->rewind());
+    }
+
+    /**
+     * @covers Noodlehaus\AbstractConfig::valid()
+     */
+    public function testValid()
+    {
+        /* Reset to the beginning of the test config */
+        $this->config->rewind();
+        $this->assertTrue($this->config->valid());
+
+        /* Step through each of the other elements of the test config */
+        $this->config->next();
+        $this->assertTrue($this->config->valid());
+        $this->config->next();
+        $this->assertTrue($this->config->valid());
+        $this->config->next();
+        $this->assertTrue($this->config->valid());
+
+        /* Step beyond the end and confirm the result */
+        $this->config->next();
+        $this->assertFalse($this->config->valid());
+    }
+
+    /**
+     * Tests to verify that Iterator is properly implemented by using a foreach
+     * loop on the test config
+     */
+    public function testIterator()
+    {
+        /* Create numerically indexed copies of the test config */
+        $expectedKeys = array ('host', 'port', 'servers', 'application');
+        $expectedValues = array (
+            'localhost',
+            80,
+            array ('host1', 'host2', 'host3'),
+            array (
+                'name'   => 'configuration',
+                'secret' => 's3cr3t'
+            )
+        );
+
+        $idxConfig = 0;
+
+        foreach ($this->config as $configKey => $configValue) {
+            $this->assertEquals($expectedKeys [$idxConfig], $configKey);
+            $this->assertEquals($expectedValues [$idxConfig], $configValue);
+            $idxConfig++;
+        }
+    }
 }

--- a/tests/AbstractConfigTest.php
+++ b/tests/AbstractConfigTest.php
@@ -320,12 +320,12 @@ class AbstractConfigTest extends \PHPUnit_Framework_TestCase
     public function testIterator()
     {
         /* Create numerically indexed copies of the test config */
-        $expectedKeys = array ('host', 'port', 'servers', 'application');
-        $expectedValues = array (
+        $expectedKeys = array('host', 'port', 'servers', 'application');
+        $expectedValues = array(
             'localhost',
             80,
-            array ('host1', 'host2', 'host3'),
-            array (
+            array('host1', 'host2', 'host3'),
+            array(
                 'name'   => 'configuration',
                 'secret' => 's3cr3t'
             )


### PR DESCRIPTION
In its current form Config is good for loading values from a file and then retrieving those values based on a known list of names. There is no current way, however, to iterate through the values without already knowing their names.

To remedy this I've implemented the Iterator interface in AbstractConfig. Users will now be able to, for example, use a foreach loop to examine each value within a loaded file.
