### PR TITLE
Config::has should check for key presence

### DIFF
--- a/src/AbstractConfig.php
+++ b/src/AbstractConfig.php
@@ -35,7 +35,7 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
      *
      * @param array $data
      */
-    public function __construct(Array $data)
+    public function __construct(array $data)
     {
         $this->data = array_merge($this->getDefaults(), $data);
     }
@@ -96,7 +96,7 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
 
         // Look for the key, creating nested keys if needed
         while ($part = array_shift($segs)) {
-            if($cacheKey != ''){
+            if ($cacheKey != '') {
                 $cacheKey .= '.';
             }
             $cacheKey .= $part;
@@ -106,14 +106,14 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
             $root = &$root[$part];
 
             //Unset all old nested cache
-            if(isset($this->cache[$cacheKey])){
+            if (isset($this->cache[$cacheKey])) {
                 unset($this->cache[$cacheKey]);
             }
 
             //Unset all old nested cache in case of array
-            if(count($segs) == 0){
+            if (count($segs) == 0) {
                 foreach ($this->cache as $cacheLocalKey => $cacheValue) {
-                    if(substr($cacheLocalKey, 0, strlen($cacheKey)) === $cacheKey){
+                    if (substr($cacheLocalKey, 0, strlen($cacheKey)) === $cacheKey) {
                         unset($this->cache[$cacheLocalKey]);
                     }
                 }

--- a/src/AbstractConfig.php
+++ b/src/AbstractConfig.php
@@ -62,27 +62,11 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
      */
     public function get($key, $default = null)
     {
-        // Check if already cached
-        if (isset($this->cache[$key])) {
+        if ($this->has($key)) {
             return $this->cache[$key];
         }
 
-        $segs = explode('.', $key);
-        $root = $this->data;
-
-        // nested case
-        foreach ($segs as $part) {
-            if (isset($root[$part])) {
-                $root = $root[$part];
-                continue;
-            } else {
-                $root = $default;
-                break;
-            }
-        }
-
-        // whatever we have is what we needed
-        return ($this->cache[$key] = $root);
+        return $default;
     }
 
     /**
@@ -129,7 +113,28 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
      */
     public function has($key)
     {
-        return !is_null($this->get($key));
+        // Check if already cached
+        if (isset($this->cache[$key])) {
+            return true;
+        }
+
+        $segments = explode('.', $key);
+        $root = $this->data;
+
+        // nested case
+        foreach ($segments as $segment) {
+            if (array_key_exists($segment, $root)) {
+                $root = $root[$segment];
+                continue;
+            } else {
+                return false;
+            }
+        }
+
+        // Set cache for the given key
+        $this->cache[$key] = $root;
+
+        return true;
     }
 
     /**
@@ -139,8 +144,6 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
     {
         return $this->data;
     }
-
-
 
     /**
      * ArrayAccess Methods

--- a/src/Config.php
+++ b/src/Config.php
@@ -58,7 +58,11 @@ class Config extends AbstractConfig
 
             // Get file information
             $info      = pathinfo($path);
-            $extension = isset($info['extension']) ? $info['extension'] : '';
+            $parts = explode('.', $info['basename']);
+            $extension = array_pop($parts);
+            if ($extension === 'dist') {
+                $extension = array_pop($parts);
+            }
             $parser    = $this->getParser($extension);
 
             // Try and load file

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -52,5 +52,4 @@ interface ConfigInterface
      * @return array
      */
     public function all();
-
 }

--- a/src/ErrorException.php
+++ b/src/ErrorException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Noodlehaus;
+
+class ErrorException extends \ErrorException
+{
+}

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Noodlehaus;
+
+class Exception extends \Exception
+{
+}

--- a/src/Exception/EmptyDirectoryException.php
+++ b/src/Exception/EmptyDirectoryException.php
@@ -2,7 +2,7 @@
 
 namespace Noodlehaus\Exception;
 
-use Exception;
+use Noodlehaus\Exception;
 
 class EmptyDirectoryException extends Exception
 {

--- a/src/Exception/FileNotFoundException.php
+++ b/src/Exception/FileNotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Noodlehaus\Exception;
 
-use Exception;
+use Noodlehaus\Exception;
 
 class FileNotFoundException extends Exception
 {

--- a/src/Exception/ParseException.php
+++ b/src/Exception/ParseException.php
@@ -2,7 +2,7 @@
 
 namespace Noodlehaus\Exception;
 
-use ErrorException;
+use Noodlehaus\ErrorException;
 
 class ParseException extends ErrorException
 {

--- a/src/Exception/UnsupportedFormatException.php
+++ b/src/Exception/UnsupportedFormatException.php
@@ -2,7 +2,7 @@
 
 namespace Noodlehaus\Exception;
 
-use Exception;
+use Noodlehaus\Exception;
 
 class UnsupportedFormatException extends Exception
 {

--- a/src/FileParser/Json.php
+++ b/src/FileParser/Json.php
@@ -25,13 +25,12 @@ class Json implements FileParserInterface
     {
         $data = json_decode(file_get_contents($path), true);
 
-        if (function_exists('json_last_error_msg')) {
-            $error_message = json_last_error_msg();
-        } else {
-            $error_message  = 'Syntax error';
-        }
-
         if (json_last_error() !== JSON_ERROR_NONE) {
+            $error_message  = 'Syntax error';
+            if (function_exists('json_last_error_msg')) {
+                $error_message = json_last_error_msg();
+            }
+
             $error = array(
                 'message' => $error_message,
                 'type'    => json_last_error(),

--- a/tests/AbstractConfigTest.php
+++ b/tests/AbstractConfigTest.php
@@ -30,8 +30,10 @@ class AbstractConfigTest extends \PHPUnit_Framework_TestCase
                 ),
                 'application' => array(
                     'name'   => 'configuration',
-                    'secret' => 's3cr3t'
-                )
+                    'secret' => 's3cr3t',
+                    'runtime' => null,
+                ),
+                'user' => null,
             )
         );
     }
@@ -115,7 +117,7 @@ class AbstractConfigTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertArrayHasKey('name', $this->config->get('application'));
         $this->assertEquals('configuration', $this->config->get('application.name'));
-        $this->assertCount(2, $this->config->get('application'));
+        $this->assertCount(3, $this->config->get('application'));
     }
 
     /**
@@ -238,6 +240,7 @@ class AbstractConfigTest extends \PHPUnit_Framework_TestCase
     public function testHas()
     {
         $this->assertTrue($this->config->has('application'));
+        $this->assertTrue($this->config->has('user'));
         $this->assertFalse($this->config->has('not_exist'));
     }
 
@@ -247,6 +250,7 @@ class AbstractConfigTest extends \PHPUnit_Framework_TestCase
     public function testHasNestedKey()
     {
         $this->assertTrue($this->config->has('application.name'));
+        $this->assertTrue($this->config->has('application.runtime'));
         $this->assertFalse($this->config->has('application.not_exist'));
         $this->assertFalse($this->config->has('not_exist.name'));
     }
@@ -266,8 +270,10 @@ class AbstractConfigTest extends \PHPUnit_Framework_TestCase
             ),
             'application' => array(
                 'name'   => 'configuration',
-                'secret' => 's3cr3t'
-            )
+                'secret' => 's3cr3t',
+                'runtime' => null,
+            ),
+            'user' => null,
         );
         $this->assertEquals($all, $this->config->all());
     }
@@ -338,6 +344,8 @@ class AbstractConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->config['servers'], $this->config->current());
         $this->config->next();
         $this->assertEquals($this->config['application'], $this->config->current());
+        $this->config->next();
+        $this->assertEquals($this->config['user'], $this->config->current());
 
         /* Step beyond the end and confirm the result */
         $this->config->next();
@@ -360,6 +368,8 @@ class AbstractConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('servers', $this->config->key());
         $this->config->next();
         $this->assertEquals('application', $this->config->key());
+        $this->config->next();
+        $this->assertEquals('user', $this->config->key());
 
         /* Step beyond the end and confirm the result */
         $this->config->next();
@@ -378,6 +388,7 @@ class AbstractConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->config['port'], $this->config->next());
         $this->assertEquals($this->config['servers'], $this->config->next());
         $this->assertEquals($this->config['application'], $this->config->next());
+        $this->assertEquals($this->config['user'], $this->config->next());
 
         /* Step beyond the end and confirm the result */
         $this->assertFalse($this->config->next());
@@ -413,6 +424,8 @@ class AbstractConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->config->valid());
         $this->config->next();
         $this->assertTrue($this->config->valid());
+        $this->config->next();
+        $this->assertTrue($this->config->valid());
 
         /* Step beyond the end and confirm the result */
         $this->config->next();
@@ -426,23 +439,32 @@ class AbstractConfigTest extends \PHPUnit_Framework_TestCase
     public function testIterator()
     {
         /* Create numerically indexed copies of the test config */
-        $expectedKeys = array('host', 'port', 'servers', 'application');
+        $expectedKeys = array('host', 'port', 'servers', 'application', 'user');
         $expectedValues = array(
             'localhost',
             80,
             array('host1', 'host2', 'host3'),
             array(
                 'name'   => 'configuration',
-                'secret' => 's3cr3t'
-            )
+                'secret' => 's3cr3t',
+                'runtime' => null,
+            ),
+            null
         );
 
         $idxConfig = 0;
 
         foreach ($this->config as $configKey => $configValue) {
-            $this->assertEquals($expectedKeys [$idxConfig], $configKey);
-            $this->assertEquals($expectedValues [$idxConfig], $configValue);
+            $this->assertEquals($expectedKeys[$idxConfig], $configKey);
+            $this->assertEquals($expectedValues[$idxConfig], $configValue);
             $idxConfig++;
         }
+    }
+
+    public function testGetShouldNotSet()
+    {
+        $this->config->get('invalid', 'default');
+        $actual = $this->config->get('invalid', 'expected');
+        $this->assertSame('expected', $actual);
     }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -175,7 +175,23 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $actual);
     }
-    
+
+    /**
+     * @covers Noodlehaus\Config::__construct()
+     * @covers Noodlehaus\Config::getParser()
+     * @covers Noodlehaus\Config::getPathFromArray()
+     * @covers Noodlehaus\Config::getValidPath()
+     */
+    public function testConstructWithYmlDist()
+    {
+        $config = new Config(__DIR__ . '/mocks/pass/config.yml.dist');
+
+        $expected = 'localhost';
+        $actual   = $config->get('host');
+
+        $this->assertEquals($expected, $actual);
+    }
+
     /**
      * @covers Noodlehaus\Config::__construct()
      * @covers Noodlehaus\Config::getParser()

--- a/tests/mocks/pass/config.yml.dist
+++ b/tests/mocks/pass/config.yml.dist
@@ -1,0 +1,9 @@
+application:
+    name: configuration
+    secret: s3cr3t
+host: localhost
+port: 80
+servers:
+- host1
+- host2
+- host3


### PR DESCRIPTION
The current code in `AbstractConfig::has` is not going to return an expected result if the value in the configuration is `null`.

``` php
    public function has($key)
    {
        return !is_null($this->get($key));
    }
```

``` yaml
somekey: null
```

In this particular case, `AbstractConfig::has` will return `false` even if it `has` the key `somekey`.
