### PR TITLE
Add support for .dist extensions files

### DIFF
--- a/src/AbstractConfig.php
+++ b/src/AbstractConfig.php
@@ -35,7 +35,7 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
      *
      * @param array $data
      */
-    public function __construct(Array $data)
+    public function __construct(array $data)
     {
         $this->data = array_merge($this->getDefaults(), $data);
     }
@@ -96,7 +96,7 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
 
         // Look for the key, creating nested keys if needed
         while ($part = array_shift($segs)) {
-            if($cacheKey != ''){
+            if ($cacheKey != '') {
                 $cacheKey .= '.';
             }
             $cacheKey .= $part;
@@ -106,14 +106,14 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
             $root = &$root[$part];
 
             //Unset all old nested cache
-            if(isset($this->cache[$cacheKey])){
+            if (isset($this->cache[$cacheKey])) {
                 unset($this->cache[$cacheKey]);
             }
 
             //Unset all old nested cache in case of array
-            if(count($segs) == 0){
+            if (count($segs) == 0) {
                 foreach ($this->cache as $cacheLocalKey => $cacheValue) {
-                    if(substr($cacheLocalKey, 0, strlen($cacheKey)) === $cacheKey){
+                    if (substr($cacheLocalKey, 0, strlen($cacheKey)) === $cacheKey) {
                         unset($this->cache[$cacheLocalKey]);
                     }
                 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -58,7 +58,11 @@ class Config extends AbstractConfig
 
             // Get file information
             $info      = pathinfo($path);
-            $extension = isset($info['extension']) ? $info['extension'] : '';
+            $parts = explode('.', $info['basename']);
+            $extension = array_pop($parts);
+            if ($extension === 'dist') {
+                $extension = array_pop($parts);
+            }
             $parser    = $this->getParser($extension);
 
             // Try and load file

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -52,5 +52,4 @@ interface ConfigInterface
      * @return array
      */
     public function all();
-
 }

--- a/src/ErrorException.php
+++ b/src/ErrorException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Noodlehaus;
+
+class ErrorException extends \ErrorException
+{
+}

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Noodlehaus;
+
+class Exception extends \Exception
+{
+}

--- a/src/Exception/EmptyDirectoryException.php
+++ b/src/Exception/EmptyDirectoryException.php
@@ -2,7 +2,7 @@
 
 namespace Noodlehaus\Exception;
 
-use Exception;
+use Noodlehaus\Exception;
 
 class EmptyDirectoryException extends Exception
 {

--- a/src/Exception/FileNotFoundException.php
+++ b/src/Exception/FileNotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Noodlehaus\Exception;
 
-use Exception;
+use Noodlehaus\Exception;
 
 class FileNotFoundException extends Exception
 {

--- a/src/Exception/ParseException.php
+++ b/src/Exception/ParseException.php
@@ -2,7 +2,7 @@
 
 namespace Noodlehaus\Exception;
 
-use ErrorException;
+use Noodlehaus\ErrorException;
 
 class ParseException extends ErrorException
 {

--- a/src/Exception/UnsupportedFormatException.php
+++ b/src/Exception/UnsupportedFormatException.php
@@ -2,7 +2,7 @@
 
 namespace Noodlehaus\Exception;
 
-use Exception;
+use Noodlehaus\Exception;
 
 class UnsupportedFormatException extends Exception
 {

--- a/src/FileParser/Json.php
+++ b/src/FileParser/Json.php
@@ -25,13 +25,12 @@ class Json implements FileParserInterface
     {
         $data = json_decode(file_get_contents($path), true);
 
-        if (function_exists('json_last_error_msg')) {
-            $error_message = json_last_error_msg();
-        } else {
-            $error_message  = 'Syntax error';
-        }
-
         if (json_last_error() !== JSON_ERROR_NONE) {
+            $error_message  = 'Syntax error';
+            if (function_exists('json_last_error_msg')) {
+                $error_message = json_last_error_msg();
+            }
+
             $error = array(
                 'message' => $error_message,
                 'type'    => json_last_error(),

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -175,7 +175,23 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $actual);
     }
-    
+
+    /**
+     * @covers Noodlehaus\Config::__construct()
+     * @covers Noodlehaus\Config::getParser()
+     * @covers Noodlehaus\Config::getPathFromArray()
+     * @covers Noodlehaus\Config::getValidPath()
+     */
+    public function testConstructWithYmlDist()
+    {
+        $config = new Config(__DIR__ . '/mocks/pass/config.yml.dist');
+
+        $expected = 'localhost';
+        $actual   = $config->get('host');
+
+        $this->assertEquals($expected, $actual);
+    }
+
     /**
      * @covers Noodlehaus\Config::__construct()
      * @covers Noodlehaus\Config::getParser()

--- a/tests/mocks/pass/config.yml.dist
+++ b/tests/mocks/pass/config.yml.dist
@@ -1,0 +1,9 @@
+application:
+    name: configuration
+    secret: s3cr3t
+host: localhost
+port: 80
+servers:
+- host1
+- host2
+- host3


### PR DESCRIPTION
In the documentation, dist files are listed as `config.dist.json`, `config.dist.xml` or `config.dist.yml` or so. However, many popular projects such as Symfony and PHPUnit use the `file.dist` extension to identify their redistributable configuration files.

This little change should allow us to support such files while at the same time still support all the previous files it supported.
