### PR TITLE
Provide package-level exceptions

### DIFF
--- a/src/ErrorException.php
+++ b/src/ErrorException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Noodlehaus;
+
+class ErrorException extends \ErrorException
+{
+}

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Noodlehaus;
+
+class Exception extends \Exception
+{
+}

--- a/src/Exception/EmptyDirectoryException.php
+++ b/src/Exception/EmptyDirectoryException.php
@@ -2,7 +2,7 @@
 
 namespace Noodlehaus\Exception;
 
-use Exception;
+use Noodlehaus\Exception;
 
 class EmptyDirectoryException extends Exception
 {

--- a/src/Exception/FileNotFoundException.php
+++ b/src/Exception/FileNotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Noodlehaus\Exception;
 
-use Exception;
+use Noodlehaus\Exception;
 
 class FileNotFoundException extends Exception
 {

--- a/src/Exception/ParseException.php
+++ b/src/Exception/ParseException.php
@@ -2,7 +2,7 @@
 
 namespace Noodlehaus\Exception;
 
-use ErrorException;
+use Noodlehaus\ErrorException;
 
 class ParseException extends ErrorException
 {

--- a/src/Exception/UnsupportedFormatException.php
+++ b/src/Exception/UnsupportedFormatException.php
@@ -2,7 +2,7 @@
 
 namespace Noodlehaus\Exception;
 
-use Exception;
+use Noodlehaus\Exception;
 
 class UnsupportedFormatException extends Exception
 {


### PR DESCRIPTION
Provide package-level exceptions, so that callers can catch at the package level.
