### PR TITLE
Add support for .dist extensions files

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -58,7 +58,11 @@ class Config extends AbstractConfig
 
             // Get file information
             $info      = pathinfo($path);
-            $extension = isset($info['extension']) ? $info['extension'] : '';
+            $parts = explode('.', $info['basename']);
+            $extension = array_pop($parts);
+            if ($extension === 'dist') {
+                $extension = array_pop($parts);
+            }
             $parser    = $this->getParser($extension);
 
             // Try and load file

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -175,7 +175,23 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $actual);
     }
-    
+
+    /**
+     * @covers Noodlehaus\Config::__construct()
+     * @covers Noodlehaus\Config::getParser()
+     * @covers Noodlehaus\Config::getPathFromArray()
+     * @covers Noodlehaus\Config::getValidPath()
+     */
+    public function testConstructWithYmlDist()
+    {
+        $config = new Config(__DIR__ . '/mocks/pass/config.yml.dist');
+
+        $expected = 'localhost';
+        $actual   = $config->get('host');
+
+        $this->assertEquals($expected, $actual);
+    }
+
     /**
      * @covers Noodlehaus\Config::__construct()
      * @covers Noodlehaus\Config::getParser()

--- a/tests/mocks/pass/config.yml.dist
+++ b/tests/mocks/pass/config.yml.dist
@@ -1,0 +1,9 @@
+application:
+    name: configuration
+    secret: s3cr3t
+host: localhost
+port: 80
+servers:
+- host1
+- host2
+- host3


### PR DESCRIPTION
In the documentation, dist files are listed as `config.dist.json`, `config.dist.xml` or `config.dist.yml` or so. However, many popular projects such as Symfony and PHPUnit use the `file.dist` extension to identify their redistributable configuration files.

This little change should allow us to support such files while at the same time still support all the previous files it supported.
