### PR TITLE
use static method to obtain supported extensions

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -86,21 +86,14 @@ class Config extends AbstractConfig
         $parser = null;
 
         foreach ($this->supportedFileParsers as $fileParser) {
-            $tempParser = new $fileParser;
-
-            if (in_array($extension, $tempParser->getSupportedExtensions($extension))) {
-                $parser = $tempParser;
-                continue;
+            if (in_array($extension, $fileParser::getSupportedExtensions($extension))) {
+                return new $fileParser();
             }
 
         }
 
         // If none exist, then throw an exception
-        if ($parser === null) {
-            throw new UnsupportedFormatException('Unsupported configuration format');
-        }
-
-        return $parser;
+        throw new UnsupportedFormatException('Unsupported configuration format');
     }
 
     /**

--- a/src/FileParser/FileParserInterface.php
+++ b/src/FileParser/FileParserInterface.php
@@ -27,5 +27,5 @@ interface FileParserInterface
      *
      * @return array
      */
-    public function getSupportedExtensions();
+    public static function getSupportedExtensions();
 }

--- a/src/FileParser/Ini.php
+++ b/src/FileParser/Ini.php
@@ -30,6 +30,32 @@ class Ini implements FileParserInterface
             throw new ParseException($error);
         }
 
+        return $this->expandDottedKey($data);
+    }
+
+    /**
+     * Expand array with dotted keys to multidimensional array
+     *
+     * @param array $data
+     *
+     * @return array
+     */
+    protected function expandDottedKey($data)
+    {
+        foreach ($data as $key => $value) {
+            if (($found = strpos($key, '.')) !== false) {
+                $newKey = substr($key, 0, $found);
+                $remainder = substr($key, $found + 1);
+
+                $expandedValue = $this->expandDottedKey([$remainder => $value]);
+                if (isset($data[$newKey])) {
+                    $data[$newKey] = array_merge_recursive($data[$newKey], $expandedValue);
+                } else {
+                    $data[$newKey] = $expandedValue;
+                }
+                unset($data[$key]);
+            }
+        }
         return $data;
     }
 

--- a/src/FileParser/Ini.php
+++ b/src/FileParser/Ini.php
@@ -36,7 +36,7 @@ class Ini implements FileParserInterface
     /**
      * {@inheritDoc}
      */
-    public function getSupportedExtensions()
+    public static function getSupportedExtensions()
     {
         return array('ini');
     }

--- a/src/FileParser/Json.php
+++ b/src/FileParser/Json.php
@@ -45,7 +45,7 @@ class Json implements FileParserInterface
     /**
      * {@inheritDoc}
      */
-    public function getSupportedExtensions()
+    public static function getSupportedExtensions()
     {
         return array('json');
     }

--- a/src/FileParser/Php.php
+++ b/src/FileParser/Php.php
@@ -54,7 +54,7 @@ class Php implements FileParserInterface
     /**
      * {@inheritDoc}
      */
-    public function getSupportedExtensions()
+    public static function getSupportedExtensions()
     {
         return array('php');
     }

--- a/src/FileParser/Xml.php
+++ b/src/FileParser/Xml.php
@@ -48,7 +48,7 @@ class Xml implements FileParserInterface
     /**
      * {@inheritDoc}
      */
-    public function getSupportedExtensions()
+    public static function getSupportedExtensions()
     {
         return array('xml');
     }

--- a/src/FileParser/Yaml.php
+++ b/src/FileParser/Yaml.php
@@ -42,7 +42,7 @@ class Yaml implements FileParserInterface
     /**
      * {@inheritDoc}
      */
-    public function getSupportedExtensions()
+    public static function getSupportedExtensions()
     {
         return array('yaml', 'yml');
     }

--- a/tests/FileParser/IniTest.php
+++ b/tests/FileParser/IniTest.php
@@ -59,4 +59,20 @@ class IniTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('localhost', $actual['host']);
         $this->assertEquals('80', $actual['port']);
     }
+
+    /**
+     * @covers Noodlehaus\FileParser\Ini::parse()
+     * @covers Noodlehaus\FileParser\Ini::expandDottedKey()
+     */
+    public function testLoadIniWithDottedName()
+    {
+        $actual = $this->ini->parse(__DIR__ . '/../mocks/pass/config2.ini');
+        $expected = ['host1', 'host2', 'host3'];
+
+        print_r($actual);
+        $this->assertEquals($expected, $actual['network']['group']['servers']);
+
+        $this->assertEquals('localhost', $actual['network']['http']['host']);
+        $this->assertEquals('80', $actual['network']['http']['port']);
+    }
 }

--- a/tests/mocks/pass/config2.ini
+++ b/tests/mocks/pass/config2.ini
@@ -1,0 +1,12 @@
+host = localhost
+port = 80
+
+network.http.host = localhost
+network.http.port = 80
+network.group.servers[] = host1
+network.group.servers[] = host2
+network.group.servers[] = host3
+
+[application]
+name = configuration
+secret = s3cr3t


### PR DESCRIPTION
With this approach there is no need to instantiate a parser to check its supported file extensions
