### PR TITLE
fix for issue #86

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The `Config` object can be created via the factory method `load()`, or
 by direct instantiation:
 
 ```php
+use Noodlehaus\Config;
+
 // Load a single file
 $conf = Config::load('config.json');
 $conf = new Config('config.json');

--- a/src/FileParser/Ini.php
+++ b/src/FileParser/Ini.php
@@ -15,6 +15,8 @@ use Noodlehaus\Exception\ParseException;
  */
 class Ini implements FileParserInterface
 {
+
+
     /**
      * {@inheritDoc}
      * Parses an INI file as an array
@@ -27,6 +29,18 @@ class Ini implements FileParserInterface
 
         if (!$data) {
             $error = error_get_last();
+
+            // parse_ini_file() may return NULL but set no error if the file contains no parsable data
+            if (!is_array($error)) {
+                $error["message"] = "No parsable content in file.";
+            }
+
+            // if file contains no parsable data, no error is set, resulting in any previous error
+            // persisting in error_get_last(). in php 7 this can be addressed with error_clear_last()
+            if (function_exists("error_clear_last")) {
+                error_clear_last();
+            }
+
             throw new ParseException($error);
         }
 

--- a/tests/FileParser/IniTest.php
+++ b/tests/FileParser/IniTest.php
@@ -43,6 +43,18 @@ class IniTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers                   Noodlehaus\FileParser\Ini::parse()
      * @expectedException        Noodlehaus\Exception\ParseException
+     * @expectedExceptionMessage No parsable content in file.
+     * Tests the case where an .ini file contains no parsable data at all, resulting in parse_ini_file
+     * returning NULL, but not setting an error retrievable by error_get_last()
+     */
+    public function testLoadInvalidIniGBH()
+    {
+        $this->ini->parse(__DIR__ . '/../mocks/fail/error2.ini');
+    }
+
+    /**
+     * @covers                   Noodlehaus\FileParser\Ini::parse()
+     * @expectedException        Noodlehaus\Exception\ParseException
      * @expectedExceptionMessage syntax error, unexpected $end, expecting ']'
      */
     public function testLoadInvalidIni()

--- a/tests/mocks/fail/error2.ini
+++ b/tests/mocks/fail/error2.ini
@@ -1,0 +1,1 @@
+unparsable content


### PR DESCRIPTION
addressing how parse_ini_file handles files that contain no ini-style data. issue #86 
