### PR TITLE
Parameter support

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -49,7 +49,7 @@ class Config extends AbstractConfig
      * @param string|array $path
      * @param array        $parameters
      */
-    public function __construct($path, array $parameters = [])
+    public function __construct($path, array $parameters = null)
     {
         $paths      = $this->getValidPath($path);
         $this->data = array();
@@ -69,7 +69,9 @@ class Config extends AbstractConfig
             $this->data = array_replace_recursive($this->data, (array) $parser->parse($path));
         }
 
-        $this->replaceParameters($this->data, new Config($parameters));
+        if (null !== $parameters) {
+            $this->replaceParameters($this->data, new DataConfig($parameters));
+        }
 
         parent::__construct($this->data);
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -83,10 +83,9 @@ class Config extends AbstractConfig
     protected function replaceParameters(array &$data, ConfigInterface $parameters)
     {
         foreach ($data as &$value) {
-            if (is_array($value)) {
+            if (true === is_array($value)) {
                 $this->replaceParameters($value, $parameters);
-                continue;
-            } elseif (is_string($value)) {
+            } elseif (true === is_string($value)) {
                 $value = preg_replace_callback('/%([^%]+)%/', function ($m) use ($parameters) {
                     if (null === $parameterValue = $parameters->get($m[1])) {
                         throw new ParseException(

--- a/src/Config.php
+++ b/src/Config.php
@@ -34,11 +34,12 @@ class Config extends AbstractConfig
     /**
      * Static method for loading a Config instance.
      *
-     * @param  string|array $path
+     * @param string|array $path
+     * @param array        $parameters
      *
      * @return Config
      */
-    public static function load($path, array $parameters = [])
+    public static function load($path, array $parameters = null)
     {
         return new static($path, $parameters);
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -88,9 +88,7 @@ class Config extends AbstractConfig
             } elseif (true === is_string($value)) {
                 $value = preg_replace_callback('/%([^%]+)%/', function ($m) use ($parameters) {
                     if (null === $parameterValue = $parameters->get($m[1])) {
-                        throw new ParseException(
-                            sprintf('Parameter "%s" does not exist', $m[1])
-                        );
+                        return $m[0];
                     }
                     return $parameterValue;
                 }, $value);

--- a/src/DataConfig.php
+++ b/src/DataConfig.php
@@ -2,6 +2,6 @@
 
 namespace Noodlehaus;
 
-class Config extends AbstractConfig
+class DataConfig extends AbstractConfig
 {
 }

--- a/src/DataConfig.php
+++ b/src/DataConfig.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Noodlehaus;
+
+class Config extends AbstractConfig
+{
+}


### PR DESCRIPTION
Proposal for #85 

This is a first proposal to add parameter support. At the moment no recursive parameters are supported. This proposal is implemented to preserve backward compatibility.

Let's say we call the `Config` as follows:

```php
$config = Config::load(
    ['some', 'config' ,'files'],
    ['parameters' => ['foo' => 'bar']]
);
```

we can use it in each of the config files like this:

```yml
config_key: "this is >%parameters.foo%<"
```

this will result in:

```php
['config_key' => 'this is >bar<']
```

if you use a not existing parameter in a config value it will not be replaced and the configuration parsing will not fail:

```yml
config_key: "this is a %not.existing.parameter%"
```

will result in:

```php
['config_key' => 'this is a %not.existing.parameter%']
```

Another idea would be to just merge the dynamic parameters into the config data and then allow using every config value as a parameter in another config value.