### PR TITLE
Add in LIBXML_NOCDATA option

### DIFF
--- a/src/FileParser/Xml.php
+++ b/src/FileParser/Xml.php
@@ -25,7 +25,7 @@ class Xml implements FileParserInterface
     {
         libxml_use_internal_errors(true);
 
-        $data = simplexml_load_file($path, null, LIBXML_NOERROR);
+        $data = simplexml_load_file($path, null, LIBXML_NOERROR | LIBXML_NOCDATA);
 
         if ($data === false) {
             $errors      = libxml_get_errors();

--- a/tests/FileParser/XmlTest.php
+++ b/tests/FileParser/XmlTest.php
@@ -58,5 +58,6 @@ class XmlTest extends \PHPUnit_Framework_TestCase
         $actual = $this->xml->parse(__DIR__ . '/../mocks/pass/config.xml');
         $this->assertEquals('localhost', $actual['host']);
         $this->assertEquals('80', $actual['port']);
+        $this->assertEquals('This is a long comment.', $actual['comment']);
     }
 }

--- a/tests/mocks/pass/config.xml
+++ b/tests/mocks/pass/config.xml
@@ -11,4 +11,5 @@
         <server2>host2</server2>
         <server3>host3</server3>
     </servers>
+    <comment><![CDATA[This is a long comment.]]></comment>
 </config>


### PR DESCRIPTION
This fixes an issue where if the xml configuration file has a CDATA node, it will register as a blank array despite what may be in it instead of a string.