### PR TITLE
Fix markdown for contact email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ## Security
 
-If you discover any security related issues, please email [contact@hassankhan.me](mailto:contact@hassankhan.me?subject=[SECURITY] Config Security Issue) instead of using the issue tracker.
+If you discover any security related issues, please email [contact@hassankhan.me](mailto:contact@hassankhan.me?subject=[SECURITY]%20Config%20Security%20Issue) instead of using the issue tracker.
 
 
 ## Credits


### PR DESCRIPTION
Markdown doesn't allow spaces in links, so the mailing link had been misinterpreted. Replaced spaces with `%20` in the link, and now it appears properly.