### PR TITLE
Possibility to use an own file parser

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -22,7 +22,7 @@ class Config extends AbstractConfig
      *
      * @var array
      */
-    private $supportedFileParsers = array(
+    protected $supportedFileParsers = array(
         'Noodlehaus\FileParser\Php',
         'Noodlehaus\FileParser\Ini',
         'Noodlehaus\FileParser\Json',


### PR DESCRIPTION
Hello,

this patch is needed if you want to use for example "a native" YAML parser instead of `symfony/yaml`.

Thanks