### PR TITLE
Fix #113

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -94,13 +94,13 @@ class Config extends AbstractConfig
                 $parser = $this->getParser($extension);
 
                 // Try to load file
-                $this->data = array_replace_recursive($this->data, (array) $parser->parse(file_get_contents($path)));
+                $this->data = array_replace_recursive($this->data, (array) $parser->parseFile($path));
 
                 // Clean parser
                 $parser = null;
             } else {
                 // Try to load file using specified parser
-                $this->data = array_replace_recursive($this->data, (array) $parser->parse(file_get_contents($path)));
+                $this->data = array_replace_recursive($this->data, (array) $parser->parseFile($path));
             }
         }
     }
@@ -116,7 +116,7 @@ class Config extends AbstractConfig
         $this->data = [];
 
         // Try to parse string
-        $this->data = array_replace_recursive($this->data, (array) $parser->parse($configuration));
+        $this->data = array_replace_recursive($this->data, (array) $parser->parseString($configuration));
     }
 
     /**

--- a/src/Parser/Ini.php
+++ b/src/Parser/Ini.php
@@ -16,7 +16,17 @@ use Noodlehaus\Exception\ParseException;
  */
 class Ini implements ParserInterface
 {
-
+    /**
+     * {@inheritDoc}
+     * Parses an INI file as an array
+     *
+     * @throws ParseException If there is an error parsing the INI file
+     */
+    public function parseFile($filename)
+    {
+        $data = @parse_ini_file($filename, true);
+        return $this->parse($data, $filename);
+    }
 
     /**
      * {@inheritDoc}
@@ -24,16 +34,28 @@ class Ini implements ParserInterface
      *
      * @throws ParseException If there is an error parsing the INI string
      */
-    public function parse($config, $filename = null)
+    public function parseString($config)
     {
         $data = @parse_ini_string($config, true);
+        return $this->parse($data);
+    }
 
+    /**
+     * Completes parsing of INI data
+     *
+     * @param  array   $data
+     * @param  strring $filename
+     *
+     * @throws ParseException If there is an error parsing the INI data
+     */
+    protected function parse($data = null, $filename = null)
+    {
         if (!$data) {
             $error = error_get_last();
 
-            // parse_ini_string() may return NULL but set no error if the string contains no parsable data
+            // Parse functions may return NULL but set no error if the string contains no parsable data
             if (!is_array($error)) {
-                $error["message"] = "No parsable content in string.";
+                $error["message"] = "No parsable content in data.";
             }
 
             $error["file"] = $filename;

--- a/src/Parser/Json.php
+++ b/src/Parser/Json.php
@@ -18,14 +18,38 @@ class Json implements ParserInterface
 {
     /**
      * {@inheritDoc}
-     * Loads a JSON string as an array
+     * Parses an JSON file as an array
+     *
+     * @throws ParseException If there is an error parsing the JSON file
+     */
+    public function parseFile($filename)
+    {
+        $data = json_decode(file_get_contents($filename), true);
+        return $this->parse($data, $filename);
+    }
+
+    /**
+     * {@inheritDoc}
+     * Parses an JSON string as an array
      *
      * @throws ParseException If there is an error parsing the JSON string
      */
-    public function parse($config, $filename = null)
+    public function parseString($config)
     {
         $data = json_decode($config, true);
+        return $this->parse($data);
+    }
 
+    /**
+     * Completes parsing of JSON data
+     *
+     * @param  array   $data
+     * @param  strring $filename
+     *
+     * @throws ParseException If there is an error parsing the JSON data
+     */
+    protected function parse($data = null, $filename = null)
+    {
         if (json_last_error() !== JSON_ERROR_NONE) {
             $error_message  = 'Syntax error';
             if (function_exists('json_last_error_msg')) {

--- a/src/Parser/ParserInterface.php
+++ b/src/Parser/ParserInterface.php
@@ -15,14 +15,22 @@ namespace Noodlehaus\Parser;
 interface ParserInterface
 {
     /**
-     * Parses a configuration from `$config` and gets its contents as an array
+     * Parses a configuration from file `$filename` and gets its contents as an array
      *
-     * @param  string $config
      * @param  string $filename
      *
      * @return array
      */
-    public function parse($config, $filename = null);
+    public function parseFile($filename);
+
+    /**
+     * Parses a configuration from string `$config` and gets its contents as an array
+     *
+     * @param  string $config
+     *
+     * @return array
+     */
+    public function parseString($config);
 
     /**
      * Returns an array of allowed file extensions for this parser

--- a/src/Parser/Php.php
+++ b/src/Parser/Php.php
@@ -52,10 +52,11 @@ class Php implements ParserInterface
      */
     public function parseString($config)
     {
-        // Strip PHP start and end tags
-        $config = str_replace('<?php', '', $config);
-        $config = str_replace('<?', '', $config);
-        $config = str_replace('?>', '', $config);
+        // Handle PHP start tag
+        $config = trim($config);
+        if (substr($config, 0, 2) === '<?') {
+            $config = '?>' . $config;
+        }
 
         // Eval the string, if it throws an exception, rethrow it
         try {

--- a/src/Parser/Xml.php
+++ b/src/Parser/Xml.php
@@ -18,16 +18,40 @@ class Xml implements ParserInterface
 {
     /**
      * {@inheritDoc}
+     * Parses an XML file as an array
+     *
+     * @throws ParseException If there is an error parsing the XML file
+     */
+    public function parseFile($filename)
+    {
+        libxml_use_internal_errors(true);
+        $data = simplexml_load_file($filename, null, LIBXML_NOERROR);
+        return $this->parse($data, $filename);
+    }
+
+    /**
+     * {@inheritDoc}
      * Parses an XML string as an array
      *
      * @throws ParseException If there is an error parsing the XML string
      */
-    public function parse($config, $filename = null)
+    public function parseString($config)
     {
         libxml_use_internal_errors(true);
-
         $data = simplexml_load_string($config, null, LIBXML_NOERROR);
+        return $this->parse($data);
+    }
 
+    /**
+     * Completes parsing of XML data
+     *
+     * @param  array   $data
+     * @param  strring $filename
+     *
+     * @throws ParseException If there is an error parsing the XML data
+     */
+    protected function parse($data = null, $filename = null)
+    {
         if ($data === false) {
             $errors      = libxml_get_errors();
             $latestError = array_pop($errors);

--- a/src/Parser/Yaml.php
+++ b/src/Parser/Yaml.php
@@ -20,11 +20,33 @@ class Yaml implements ParserInterface
 {
     /**
      * {@inheritDoc}
+     * Loads a YAML/YML file as an array
+     *
+     * @throws ParseException If If there is an error parsing the YAML file
+     */
+    public function parseFile($filename)
+    {
+        try {
+            $data = YamlParser::parseFile($filename, YamlParser::PARSE_CONSTANT);
+        } catch (Exception $exception) {
+            throw new ParseException(
+                [
+                    'message'   => 'Error parsing YAML file',
+                    'exception' => $exception,
+                ]
+            );
+        }
+
+        return $this->parse($data, $filename);
+    }
+
+    /**
+     * {@inheritDoc}
      * Loads a YAML/YML string as an array
      *
      * @throws ParseException If If there is an error parsing the YAML string
      */
-    public function parse($config, $filename = null)
+    public function parseString($config)
     {
         try {
             $data = YamlParser::parse($config, YamlParser::PARSE_CONSTANT);
@@ -37,6 +59,19 @@ class Yaml implements ParserInterface
             );
         }
 
+        return $this->parse($data);
+    }
+
+    /**
+     * Completes parsing of YAML/YML data
+     *
+     * @param  array   $data
+     * @param  strring $filename
+     *
+     * @throws ParseException If there is an error parsing the YAML data
+     */
+    protected function parse($data = null, $filename = null)
+    {
         return $data;
     }
 

--- a/tests/Parser/IniTest.php
+++ b/tests/Parser/IniTest.php
@@ -42,49 +42,65 @@ class IniTest extends TestCase
     }
 
     /**
+     * @covers                   Noodlehaus\Parser\Ini::parseFile()
      * @covers                   Noodlehaus\Parser\Ini::parse()
      * @expectedException        Noodlehaus\Exception\ParseException
-     * @expectedExceptionMessage No parsable content in string.
+     * @expectedExceptionMessage No parsable content
      * Tests the case where an INI string contains no parsable data at all, resulting in parse_ini_string
      * returning NULL, but not setting an error retrievable by error_get_last()
      */
     public function testLoadInvalidIniGBH()
     {
-        $this->ini->parse(file_get_contents(__DIR__ . '/../mocks/fail/error2.ini'));
+        $this->ini->parseFile(__DIR__ . '/../mocks/fail/error2.ini');
     }
 
     /**
+     * @covers                   Noodlehaus\Parser\Ini::parseString()
      * @covers                   Noodlehaus\Parser\Ini::parse()
      * @expectedException        Noodlehaus\Exception\ParseException
      * @expectedExceptionMessage syntax error, unexpected $end, expecting ']'
      */
     public function testLoadInvalidIni()
     {
-        $this->ini->parse(file_get_contents(__DIR__ . '/../mocks/fail/error.ini'));
+        $this->ini->parseString(file_get_contents(__DIR__ . '/../mocks/fail/error.ini'));
     }
 
     /**
+     * @covers Noodlehaus\Parser\Ini::parseFile()
+     * @covers Noodlehaus\Parser\Ini::parseString()
      * @covers Noodlehaus\Parser\Ini::parse()
      */
     public function testLoadIni()
     {
-        $actual = $this->ini->parse(file_get_contents(__DIR__ . '/../mocks/pass/config.ini'));
-        $this->assertEquals('localhost', $actual['host']);
-        $this->assertEquals('80', $actual['port']);
+        $file = $this->ini->parseFile(__DIR__ . '/../mocks/pass/config.ini');
+        $string = $this->ini->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config.ini'));
+
+        $this->assertEquals('localhost', $file['host']);
+        $this->assertEquals('80', $file['port']);
+
+        /*$this->assertEquals('localhost', $string['host']);
+        $this->assertEquals('80', $string['port']);*/
     }
 
     /**
+     * @covers Noodlehaus\Parser\Ini::parseFile()
+     * @covers Noodlehaus\Parser\Ini::parseString()
      * @covers Noodlehaus\Parser\Ini::parse()
      * @covers Noodlehaus\Parser\Ini::expandDottedKey()
      */
     public function testLoadIniWithDottedName()
     {
-        $actual = $this->ini->parse(file_get_contents(__DIR__ . '/../mocks/pass/config2.ini'));
+        $file = $this->ini->parseFile(__DIR__ . '/../mocks/pass/config2.ini');
+        $string = $this->ini->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config2.ini'));
+
         $expected = ['host1', 'host2', 'host3'];
 
-        $this->assertEquals($expected, $actual['network']['group']['servers']);
+        $this->assertEquals($expected, $file['network']['group']['servers']);
+        $this->assertEquals('localhost', $file['network']['http']['host']);
+        $this->assertEquals('80', $file['network']['http']['port']);
 
-        $this->assertEquals('localhost', $actual['network']['http']['host']);
-        $this->assertEquals('80', $actual['network']['http']['port']);
+        $this->assertEquals($expected, $string['network']['group']['servers']);
+        $this->assertEquals('localhost', $string['network']['http']['host']);
+        $this->assertEquals('80', $string['network']['http']['port']);
     }
 }

--- a/tests/Parser/JsonTest.php
+++ b/tests/Parser/JsonTest.php
@@ -42,22 +42,30 @@ class JsonTest extends TestCase
     }
 
     /**
+     * @covers                   Noodlehaus\Parser\Json::parseFile()
      * @covers                   Noodlehaus\Parser\Json::parse()
      * @expectedException        Noodlehaus\Exception\ParseException
      * @expectedExceptionMessage Syntax error
      */
     public function testLoadInvalidJson()
     {
-        $this->json->parse(file_get_contents(__DIR__ . '/../mocks/fail/error.json'));
+        $this->json->parseFile(__DIR__ . '/../mocks/fail/error.json');
     }
 
     /**
+     * @covers Noodlehaus\Parser\Json::parseFile()
+     * @covers Noodlehaus\Parser\Json::parseString()
      * @covers Noodlehaus\Parser\Json::parse()
      */
     public function testLoadJson()
     {
-        $actual = $this->json->parse(file_get_contents(__DIR__ . '/../mocks/pass/config.json'));
-        $this->assertEquals('localhost', $actual['host']);
-        $this->assertEquals('80', $actual['port']);
+        $file = $this->json->parseFile(__DIR__ . '/../mocks/pass/config.json');
+        $string = $this->json->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config.json'));
+
+        $this->assertEquals('localhost', $file['host']);
+        $this->assertEquals('80', $file['port']);
+
+        $this->assertEquals('localhost', $string['host']);
+        $this->assertEquals('80', $string['port']);
     }
 }

--- a/tests/Parser/PhpTest.php
+++ b/tests/Parser/PhpTest.php
@@ -42,42 +42,67 @@ class PhpTest extends TestCase
     }
 
     /**
+     * @covers                   Noodlehaus\Parser\Php::parseFile()
      * @covers                   Noodlehaus\Parser\Php::parse()
      * @expectedException        Noodlehaus\Exception\UnsupportedFormatException
-     * @expectedExceptionMessage PHP string does not return an array
+     * @expectedExceptionMessage PHP data does not return an array
      */
     public function testLoadInvalidPhp()
     {
-        $this->php->parse(file_get_contents(__DIR__ . '/../mocks/fail/error.php'));
+        $this->php->parseFile(__DIR__ . '/../mocks/fail/error.php');
     }
 
     /**
-     * @covers                   Noodlehaus\Parser\Php::parse()
+     * @covers                   Noodlehaus\Parser\Php::parseFile()
+     * @expectedException        Noodlehaus\Exception\ParseException
+     * @expectedExceptionMessage PHP file threw an exception
+     */
+    public function testLoadExceptionalPhpFile()
+    {
+        $this->php->parseFile(__DIR__ . '/../mocks/fail/error-exception.php');
+    }
+
+    /**
+     * @covers                   Noodlehaus\Parser\Php::parseString()
      * @expectedException        Noodlehaus\Exception\ParseException
      * @expectedExceptionMessage PHP string threw an exception
      */
-    public function testLoadExceptionalPhp()
+    public function testLoadExceptionalPhpString()
     {
-        $this->php->parse(file_get_contents(__DIR__ . '/../mocks/fail/error-exception.php'));
+        $this->php->parseString(file_get_contents(__DIR__ . '/../mocks/fail/error-exception.php'));
     }
 
     /**
+     * @covers Noodlehaus\Parser\Php::parseFile()
+     * @covers Noodlehaus\Parser\Php::parseString()
      * @covers Noodlehaus\Parser\Php::parse()
      */
     public function testLoadPhpArray()
     {
-        $actual = $this->php->parse(file_get_contents(__DIR__ . '/../mocks/pass/config.php'));
-        $this->assertEquals('localhost', $actual['host']);
-        $this->assertEquals('80', $actual['port']);
+        $file = $this->php->parseFile(__DIR__ . '/../mocks/pass/config.php');
+        $string = $this->php->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config.php'));
+
+        $this->assertEquals('localhost', $file['host']);
+        $this->assertEquals('80', $file['port']);
+
+        $this->assertEquals('localhost', $string['host']);
+        $this->assertEquals('80', $string['port']);
     }
 
     /**
+     * @covers Noodlehaus\Parser\Php::parseFile()
+     * @covers Noodlehaus\Parser\Php::parseString()
      * @covers Noodlehaus\Parser\Php::parse()
      */
     public function testLoadPhpCallable()
     {
-        $actual = $this->php->parse(file_get_contents(__DIR__ . '/../mocks/pass/config-exec.php'));
-        $this->assertEquals('localhost', $actual['host']);
-        $this->assertEquals('80', $actual['port']);
+        $file = $this->php->parseFile(__DIR__ . '/../mocks/pass/config-exec.php');
+        $string = $this->php->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config-exec.php'));
+
+        $this->assertEquals('localhost', $file['host']);
+        $this->assertEquals('80', $file['port']);
+
+        $this->assertEquals('localhost', $string['host']);
+        $this->assertEquals('80', $string['port']);
     }
 }

--- a/tests/Parser/XmlTest.php
+++ b/tests/Parser/XmlTest.php
@@ -42,22 +42,30 @@ class XmlTest extends TestCase
     }
 
     /**
+     * @covers                   Noodlehaus\Parser\Xml::parseFile()
      * @covers                   Noodlehaus\Parser\Xml::parse()
      * @expectedException        Noodlehaus\Exception\ParseException
      * @expectedExceptionMessage Opening and ending tag mismatch: name line 4
      */
     public function testLoadInvalidXml()
     {
-        $this->xml->parse(file_get_contents(__DIR__ . '/../mocks/fail/error.xml'));
+        $this->xml->parseFile(__DIR__ . '/../mocks/fail/error.xml');
     }
 
     /**
+     * @covers Noodlehaus\Parser\Xml::parseFile()
+     * @covers Noodlehaus\Parser\Xml::parseString()
      * @covers Noodlehaus\Parser\Xml::parse()
      */
     public function testLoadXml()
     {
-        $actual = $this->xml->parse(file_get_contents(__DIR__ . '/../mocks/pass/config.xml'));
-        $this->assertEquals('localhost', $actual['host']);
-        $this->assertEquals('80', $actual['port']);
+        $file = $this->xml->parseFile(__DIR__ . '/../mocks/pass/config.xml');
+        $string = $this->xml->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config.xml'));
+
+        $this->assertEquals('localhost', $file['host']);
+        $this->assertEquals('80', $file['port']);
+
+        $this->assertEquals('localhost', $string['host']);
+        $this->assertEquals('80', $string['port']);
     }
 }

--- a/tests/Parser/YamlTest.php
+++ b/tests/Parser/YamlTest.php
@@ -42,21 +42,34 @@ class YamlTest extends TestCase
     }
 
     /**
+     * @covers                   Noodlehaus\Parser\Yaml::parseFile()
+     * @covers                   Noodlehaus\Parser\Yaml::parse()
+     * @expectedException        Noodlehaus\Exception\ParseException
+     * @expectedExceptionMessage Error parsing YAML file
+     */
+    public function testLoadInvalidYamlFile()
+    {
+        $this->yaml->parseFile(__DIR__ . '/../mocks/fail/error.yaml');
+    }
+
+    /**
+     * @covers                   Noodlehaus\Parser\Yaml::parseString()
      * @covers                   Noodlehaus\Parser\Yaml::parse()
      * @expectedException        Noodlehaus\Exception\ParseException
      * @expectedExceptionMessage Error parsing YAML string
      */
-    public function testLoadInvalidYaml()
+    public function testLoadInvalidYamlString()
     {
-        $this->yaml->parse(file_get_contents(__DIR__ . '/../mocks/fail/error.yaml'));
+        $this->yaml->parseString(file_get_contents(__DIR__ . '/../mocks/fail/error.yaml'));
     }
 
     /**
+     * @covers Noodlehaus\Parser\Yaml::parseFile()
      * @covers Noodlehaus\Parser\Yaml::parse()
      */
     public function testLoadYaml()
     {
-        $actual = $this->yaml->parse(file_get_contents(__DIR__ . '/../mocks/pass/config.yaml'));
+        $actual = $this->yaml->parseFile(__DIR__ . '/../mocks/pass/config.yaml');
         $this->assertEquals('localhost', $actual['host']);
         $this->assertEquals('80', $actual['port']);
     }
@@ -66,7 +79,17 @@ class YamlTest extends TestCase
      */
     public function testLoadYml()
     {
-        $actual = $this->yaml->parse(file_get_contents(__DIR__ . '/../mocks/pass/config.yml'));
+        $actual = $this->yaml->parseFile(__DIR__ . '/../mocks/pass/config.yml');
+        $this->assertEquals('localhost', $actual['host']);
+        $this->assertEquals('80', $actual['port']);
+    }
+
+    /**
+     * @covers Noodlehaus\Parser\Yaml::parseString()
+     */
+    public function testLoadYamlString()
+    {
+        $actual = $this->yaml->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config.yaml'));
         $this->assertEquals('localhost', $actual['host']);
         $this->assertEquals('80', $actual['port']);
     }


### PR DESCRIPTION
It fixes #113.

It adds two separated methods for parsers `parseFile()` and `parseString()`. Both then call protected method `parse()` to complete parsing and handle errors.

~~Fix for PHP tags in strings still need to be added. It should remove only first and last line if there are `<?php`, `<?` or `?>`. If possible, other solution should be https://github.com/hassankhan/config/issues/113#issuecomment-427907512.
How can I make this?~~ (fixed in 22b60dcb84097e7129739a21a17e38d0f1b0f318)

---

This code should work, but maybe there should be better code style and tests.