### PR TITLE
added test showing section override

### DIFF
--- a/tests/AbstractConfigTest.php
+++ b/tests/AbstractConfigTest.php
@@ -502,4 +502,16 @@ class AbstractConfigTest extends TestCase
         $this->config->remove('application');
         $this->assertNull($this->config['application']);
     }
+
+    public function testDefaultOptionsSetOnInstantiationDoNotOverwriteSections()
+    {
+        $config = new SimpleConfig(
+            [
+                'application' => ['secret' => 'verysecret']
+            ]
+        );
+        $this->assertEquals('configuration', $config->get('application.name'));
+        $this->assertEquals('verysecret', $config->get('application.secret'));
+    }    
 }
+


### PR DESCRIPTION
currently you can not overwrite a single key (e.g. 'secret' in the test method) without overwriting the whole section (e.g. 'application' in the test method).