### PR TITLE
Fix ParserInterface implementations

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -94,13 +94,13 @@ class Config extends AbstractConfig
                 $parser = $this->getParser($extension);
 
                 // Try to load file
-                $this->data = array_replace_recursive($this->data, (array) $parser->parseFile($path));
+                $this->data = array_replace_recursive($this->data, $parser->parseFile($path));
 
                 // Clean parser
                 $parser = null;
             } else {
                 // Try to load file using specified parser
-                $this->data = array_replace_recursive($this->data, (array) $parser->parseFile($path));
+                $this->data = array_replace_recursive($this->data, $parser->parseFile($path));
             }
         }
     }
@@ -116,7 +116,7 @@ class Config extends AbstractConfig
         $this->data = [];
 
         // Try to parse string
-        $this->data = array_replace_recursive($this->data, (array) $parser->parseString($configuration));
+        $this->data = array_replace_recursive($this->data, $parser->parseString($configuration));
     }
 
     /**

--- a/src/Parser/Json.php
+++ b/src/Parser/Json.php
@@ -47,7 +47,7 @@ class Json implements ParserInterface
      * Completes parsing of JSON data
      *
      * @param  array   $data
-     * @param  strring $filename
+     * @param  string $filename
      *
      * @throws ParseException If there is an error parsing the JSON data
      */
@@ -64,6 +64,7 @@ class Json implements ParserInterface
                 'type'    => json_last_error(),
                 'file'    => $filename,
             ];
+
             throw new ParseException($error);
         }
 

--- a/src/Parser/Json.php
+++ b/src/Parser/Json.php
@@ -25,7 +25,8 @@ class Json implements ParserInterface
     public function parseFile($filename)
     {
         $data = json_decode(file_get_contents($filename), true);
-        return $this->parse($data, $filename);
+        $parsed = $this->parse($data, $filename);
+        return $parsed === null ? [] : $parsed;
     }
 
     /**
@@ -37,7 +38,9 @@ class Json implements ParserInterface
     public function parseString($config)
     {
         $data = json_decode($config, true);
-        return $this->parse($data);
+        $parsed = $this->parse($data);
+
+        return $parsed === null ? [] : $parsed;
     }
 
     /**

--- a/src/Parser/Json.php
+++ b/src/Parser/Json.php
@@ -25,8 +25,8 @@ class Json implements ParserInterface
     public function parseFile($filename)
     {
         $data = json_decode(file_get_contents($filename), true);
-        $parsed = $this->parse($data, $filename);
-        return $parsed === null ? [] : $parsed;
+
+        return (array)$this->parse($data, $filename);
     }
 
     /**
@@ -38,16 +38,16 @@ class Json implements ParserInterface
     public function parseString($config)
     {
         $data = json_decode($config, true);
-        $parsed = $this->parse($data);
 
-        return $parsed === null ? [] : $parsed;
+        return (array)$this->parse($data);
     }
 
     /**
      * Completes parsing of JSON data
      *
-     * @param  array   $data
+     * @param  array  $data
      * @param  string $filename
+     * @return array|null
      *
      * @throws ParseException If there is an error parsing the JSON data
      */

--- a/src/Parser/Php.php
+++ b/src/Parser/Php.php
@@ -40,8 +40,7 @@ class Php implements ParserInterface
         }
 
         // Complete parsing
-        $parsed = $this->parse($data, $filename);
-        return $parsed === null ? [] : $parsed;
+        return (array)$this->parse($data, $filename);
     }
 
     /**
@@ -72,8 +71,7 @@ class Php implements ParserInterface
         }
 
         // Complete parsing
-        $parsed = $this->parse($data);
-        return $parsed === null ? [] : $parsed;
+        return (array)$this->parse($data);
     }
 
     /**

--- a/src/Parser/Php.php
+++ b/src/Parser/Php.php
@@ -40,7 +40,8 @@ class Php implements ParserInterface
         }
 
         // Complete parsing
-        return $this->parse($data, $filename);
+        $parsed = $this->parse($data, $filename);
+        return $parsed === null ? [] : $parsed;
     }
 
     /**
@@ -71,16 +72,18 @@ class Php implements ParserInterface
         }
 
         // Complete parsing
-        return $this->parse($data);
+        $parsed = $this->parse($data);
+        return $parsed === null ? [] : $parsed;
     }
 
     /**
      * Completes parsing of PHP data
      *
-     * @param  array   $data
-     * @param  strring $filename
+     * @param  array $data
+     * @param  string $filename
      *
-     * @throws ParseException If there is an error parsing the PHP data
+     * @return array|null
+     * @throws UnsupportedFormatException
      */
     protected function parse($data = null, $filename = null)
     {

--- a/src/Parser/Xml.php
+++ b/src/Parser/Xml.php
@@ -26,7 +26,9 @@ class Xml implements ParserInterface
     {
         libxml_use_internal_errors(true);
         $data = simplexml_load_file($filename, null, LIBXML_NOERROR);
-        return $this->parse($data, $filename);
+        $parsed = $this->parse($data, $filename);
+
+        return $parsed === null ? [] : $parsed;
     }
 
     /**
@@ -39,15 +41,18 @@ class Xml implements ParserInterface
     {
         libxml_use_internal_errors(true);
         $data = simplexml_load_string($config, null, LIBXML_NOERROR);
-        return $this->parse($data);
+        $parsed = $this->parse($data);
+
+        return $parsed === null ? [] : $parsed;
     }
 
     /**
      * Completes parsing of XML data
      *
-     * @param  array   $data
-     * @param  strring $filename
+     * @param  array $data
+     * @param  string $filename
      *
+     * @return array|null
      * @throws ParseException If there is an error parsing the XML data
      */
     protected function parse($data = null, $filename = null)

--- a/src/Parser/Xml.php
+++ b/src/Parser/Xml.php
@@ -26,9 +26,8 @@ class Xml implements ParserInterface
     {
         libxml_use_internal_errors(true);
         $data = simplexml_load_file($filename, null, LIBXML_NOERROR);
-        $parsed = $this->parse($data, $filename);
 
-        return $parsed === null ? [] : $parsed;
+        return (array)$this->parse($data, $filename);
     }
 
     /**
@@ -41,9 +40,7 @@ class Xml implements ParserInterface
     {
         libxml_use_internal_errors(true);
         $data = simplexml_load_string($config, null, LIBXML_NOERROR);
-        $parsed = $this->parse($data);
-
-        return $parsed === null ? [] : $parsed;
+        return (array)$this->parse($data);
     }
 
     /**
@@ -53,6 +50,7 @@ class Xml implements ParserInterface
      * @param  string $filename
      *
      * @return array|null
+     *
      * @throws ParseException If there is an error parsing the XML data
      */
     protected function parse($data = null, $filename = null)

--- a/src/Parser/Yaml.php
+++ b/src/Parser/Yaml.php
@@ -22,7 +22,7 @@ class Yaml implements ParserInterface
      * {@inheritDoc}
      * Loads a YAML/YML file as an array
      *
-     * @throws ParseException If If there is an error parsing the YAML file
+     * @throws ParseException If there is an error parsing the YAML file
      */
     public function parseFile($filename)
     {
@@ -37,7 +37,9 @@ class Yaml implements ParserInterface
             );
         }
 
-        return $this->parse($data, $filename);
+        $parsed = $this->parse($data);
+
+        return $parsed === null ? [] : $parsed;
     }
 
     /**
@@ -59,18 +61,19 @@ class Yaml implements ParserInterface
             );
         }
 
-        return $this->parse($data);
+        $parsed = $this->parse($data);
+
+        return $parsed === null ? [] : $parsed;
     }
 
     /**
      * Completes parsing of YAML/YML data
      *
-     * @param  array   $data
-     * @param  strring $filename
+     * @param  array $data
      *
-     * @throws ParseException If there is an error parsing the YAML data
+     * @return array|null
      */
-    protected function parse($data = null, $filename = null)
+    protected function parse($data = null)
     {
         return $data;
     }

--- a/src/Parser/Yaml.php
+++ b/src/Parser/Yaml.php
@@ -37,9 +37,7 @@ class Yaml implements ParserInterface
             );
         }
 
-        $parsed = $this->parse($data);
-
-        return $parsed === null ? [] : $parsed;
+        return (array)$this->parse($data);
     }
 
     /**
@@ -61,9 +59,7 @@ class Yaml implements ParserInterface
             );
         }
 
-        $parsed = $this->parse($data);
-
-        return $parsed === null ? [] : $parsed;
+        return (array)$this->parse($data);
     }
 
     /**


### PR DESCRIPTION
All the parsers (except ini) were not compliant with the ParserInterface.  Most of them returned array|null, rather than array defined in the interface.  Rather than fixing the parsers, (array) casts were being used in the consuming code (Config).

This PR:
- Makes all parsers compliant with the ParserInterface.
- Returns empty array in cases where null is returned from the parser parse() function.
- Removes (array) casting.
- General cleanup (remove unused params, docblocks etc).