### PR TITLE
Fix unsetting offset

### DIFF
--- a/src/AbstractConfig.php
+++ b/src/AbstractConfig.php
@@ -111,7 +111,7 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
     /**
      * {@inheritDoc}
      */
-    public function unset($key)
+    public function remove($key)
     {
         $segs = explode('.', $key);
         $root = &$this->data;
@@ -223,7 +223,7 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
      */
     public function offsetUnset($offset)
     {
-        $this->unset($offset);
+        $this->remove($offset);
     }
 
     /**
@@ -289,17 +289,5 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
     public function valid()
     {
         return (is_array($this->data) ? key($this->data) !== null : false);
-    }
-
-    /**
-     * Remove a value using the offset as a key
-     *
-     * @param  string $key
-     *
-     * @return void
-     */
-    public function remove($key)
-    {
-        $this->unset($key);
     }
 }

--- a/src/AbstractConfig.php
+++ b/src/AbstractConfig.php
@@ -111,6 +111,22 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
     /**
      * {@inheritDoc}
      */
+    public function unset($key)
+    {
+        $segs = explode('.', $key);
+        $root = &$this->data;
+
+        foreach(array_slice($segs, 0, -1) as $seg) {
+            $root = &$root[$seg];
+        }
+
+        unset($root[array_pop($segs)]);
+        unset($this->cache[$key]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function has($key)
     {
         // Check if already cached
@@ -207,7 +223,7 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
      */
     public function offsetUnset($offset)
     {
-        $this->set($offset, null);
+        $this->unset($offset);
     }
 
     /**
@@ -284,6 +300,6 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
      */
     public function remove($key)
     {
-        $this->offsetUnset($key);
+        $this->unset($key);
     }
 }

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -37,14 +37,14 @@ interface ConfigInterface
     public function set($key, $value);
 
     /**
-     * Function for unsetting configuration values, using
+     * Function for removing configuration values, using
      * either simple or nested keys.
      *
      * @param  string $key
      *
      * @return void
      */
-    public function unset($key);
+    public function remove($key);
 
     /**
      * Function for checking if configuration values exist, using

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -37,6 +37,16 @@ interface ConfigInterface
     public function set($key, $value);
 
     /**
+     * Function for unsetting configuration values, using
+     * either simple or nested keys.
+     *
+     * @param  string $key
+     *
+     * @return void
+     */
+    public function unset($key);
+
+    /**
      * Function for checking if configuration values exist, using
      * either simple or nested keys.
      *

--- a/tests/AbstractConfigTest.php
+++ b/tests/AbstractConfigTest.php
@@ -236,21 +236,21 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::unset()
+     * @covers Noodlehaus\AbstractConfig::remove()
      */
-    public function testUnsetNestedKey()
+    public function testRemoveNestedKey()
     {
-        $this->config->unset('application.name');
+        $this->config->remove('application.name');
         $this->assertTrue(is_array($this->config->get('application')));
         $this->assertArrayNotHasKey('name', $this->config->get('application'));
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::unset()
+     * @covers Noodlehaus\AbstractConfig::remove()
      */
-    public function testUnsetArray()
+    public function testRemoveArray()
     {
-        $this->config->unset('application');
+        $this->config->remove('application');
         $this->assertArrayNotHasKey('application', $this->config->all());
     }
 
@@ -511,14 +511,5 @@ class AbstractConfigTest extends TestCase
         $this->config->get('invalid', 'default');
         $actual = $this->config->get('invalid', 'expected');
         $this->assertSame('expected', $actual);
-    }
-
-    /**
-     * @covers Noodlehaus\AbstractConfig::remove()
-     */
-    public function testRemove()
-    {
-        $this->config->remove('application');
-        $this->assertArrayNotHasKey('application', $this->config->all());
     }
 }

--- a/tests/AbstractConfigTest.php
+++ b/tests/AbstractConfigTest.php
@@ -236,6 +236,25 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
+     * @covers Noodlehaus\AbstractConfig::unset()
+     */
+    public function testUnsetNestedKey()
+    {
+        $this->config->unset('application.name');
+        $this->assertTrue(is_array($this->config->get('application')));
+        $this->assertArrayNotHasKey('name', $this->config->get('application'));
+    }
+
+    /**
+     * @covers Noodlehaus\AbstractConfig::unset()
+     */
+    public function testUnsetArray()
+    {
+        $this->config->unset('application');
+        $this->assertArrayNotHasKey('application', $this->config->all());
+    }
+
+    /**
      * @covers Noodlehaus\AbstractConfig::has()
      */
     public function testHas()
@@ -351,7 +370,7 @@ class AbstractConfigTest extends TestCase
     public function testOffsetUnset()
     {
         unset($this->config['application']);
-        $this->assertNull($this->config['application']);
+        $this->assertArrayNotHasKey('application', $this->config->all());
     }
 
     /**
@@ -500,6 +519,6 @@ class AbstractConfigTest extends TestCase
     public function testRemove()
     {
         $this->config->remove('application');
-        $this->assertNull($this->config['application']);
+        $this->assertArrayNotHasKey('application', $this->config->all());
     }
 }


### PR DESCRIPTION
Fixes unsetting offset. Fixes #123.

Methods `unset`, `offsetUnset` and `remove` now delete offset from data and cache array. I used 1. solution from [here](https://github.com/hassankhan/config/issues/123#issuecomment-529660728).

We should now discuss if changing the interface is really such a breaking change. Are there actually any developers who actually implemented their own `AbstractConfig`? We can probably release as the minor/normal version, but just add in the release notes that interface is changed.