### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,14 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 install:
-  - travis_retry composer update --no-interaction --no-progress --no-suggest --prefer-dist
+  - travis_retry composer install --no-interaction --no-progress --no-suggest --prefer-dist
 
 script:
   - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.5.9"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8 || ~5.7 || ~6.5 || ~7.5",
+        "phpunit/phpunit": "~4.8.36 || ~5.7 || ~6.5 || ~7.5",
         "scrutinizer/ocular": "~1.1",
         "squizlabs/php_codesniffer": "~2.2",
         "symfony/yaml": "~3.4"

--- a/tests/AbstractConfigTest.php
+++ b/tests/AbstractConfigTest.php
@@ -148,7 +148,7 @@ class AbstractConfigTest extends TestCase
             'host' => 'localhost',
             'name' => 'mydatabase'
         ]);
-        $this->assertTrue(is_array($this->config->get('database')));
+        $this->assertInternalType('array', $this->config->get('database'));
         $this->assertEquals('localhost', $this->config->get('database.host'));
     }
 
@@ -161,7 +161,7 @@ class AbstractConfigTest extends TestCase
             'host' => 'localhost',
             'name' => 'mydatabase'
         ]);
-        $this->assertTrue(is_array($this->config->get('database')));
+        $this->assertInternalType('array', $this->config->get('database'));
         $this->config->set('database.host', '127.0.0.1');
         $expected = [
             'host' => '127.0.0.1',
@@ -227,7 +227,7 @@ class AbstractConfigTest extends TestCase
             'host' => 'localhost',
             'name' => 'mydatabase'
         ]);
-        $this->assertTrue(is_array($this->config->get('database')));
+        $this->assertInternalType('array', $this->config->get('database'));
         $this->assertEquals('localhost', $this->config->get('database.host'));
         $this->config->set('database.host', null);
         $this->assertNull($this->config->get('database.host'));

--- a/tests/Writer/IniTest.php
+++ b/tests/Writer/IniTest.php
@@ -90,7 +90,7 @@ EOD;
         $this->writer->toFile($this->data, $this->temp_file);
 
         $this->assertFileExists($this->temp_file);
-        $this->assertEquals(file_get_contents($this->temp_file), file_get_contents(__DIR__.'/../mocks/pass/config4.ini'));
+        $this->assertFileEquals($this->temp_file, __DIR__.'/../mocks/pass/config4.ini');
     }
 
     /**

--- a/tests/Writer/JsonTest.php
+++ b/tests/Writer/JsonTest.php
@@ -84,7 +84,7 @@ class JsonTest extends TestCase
         $this->writer->toFile($this->data, $this->temp_file);
 
         $this->assertFileExists($this->temp_file);
-        $this->assertEquals(file_get_contents($this->temp_file), file_get_contents(__DIR__.'/../mocks/pass/config4.json'));
+        $this->assertFileEquals($this->temp_file, __DIR__.'/../mocks/pass/config4.json');
     }
 
     /**

--- a/tests/Writer/XmlTest.php
+++ b/tests/Writer/XmlTest.php
@@ -89,7 +89,7 @@ EOD;
         $this->writer->toFile($this->data, $this->temp_file);
 
         $this->assertFileExists($this->temp_file);
-        $this->assertEquals(file_get_contents($this->temp_file), file_get_contents(__DIR__.'/../mocks/pass/config4.xml'));
+        $this->assertFileEquals($this->temp_file, __DIR__.'/../mocks/pass/config4.xml');
     }
 
     /**

--- a/tests/Writer/YamlTest.php
+++ b/tests/Writer/YamlTest.php
@@ -93,7 +93,7 @@ EOD;
     {
         $this->writer->toFile($this->data, $this->temp_file);
         $this->assertFileExists($this->temp_file);
-        $this->assertEquals(file_get_contents($this->temp_file), file_get_contents(__DIR__.'/../mocks/pass/config4.yaml'));
+        $this->assertFileEquals($this->temp_file, __DIR__.'/../mocks/pass/config4.yaml');
     }
 
     /**


### PR DESCRIPTION
# Changed log
- Using the `install` option via `composer install` is good enough to install required dependencies on Travis CI build.
- The `PHPUnit\Framework\TestCase` namespace is supported since PHPUnit version is `4.8.36`.
- Using the `assertInternalType` assertion to determine the expected type is `array`.
- Using the `assertFileEquals` to assert the expected contents of file is same as resulted contents of file.