### PR TITLE
Added support for Properties files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Gitter][ico-gitter]][link-gitter]
 
 Config is a file configuration loader that supports PHP, INI, XML, JSON,
-and YML files and strings.
+YML and Properties files and strings.
 
 ## Requirements
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -32,7 +32,7 @@ class Config extends AbstractConfig
         'Noodlehaus\Parser\Json',
         'Noodlehaus\Parser\Xml',
         'Noodlehaus\Parser\Yaml',
-        'Noodlehaus\Parser\Properties'
+        'Noodlehaus\Parser\Properties',
     ];
 
     /**
@@ -44,7 +44,8 @@ class Config extends AbstractConfig
         'Noodlehaus\Writer\Ini',
         'Noodlehaus\Writer\Json',
         'Noodlehaus\Writer\Xml',
-        'Noodlehaus\Writer\Yaml'
+        'Noodlehaus\Writer\Yaml',
+        'Noodlehaus\Writer\Properties',
     ];
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -31,7 +31,8 @@ class Config extends AbstractConfig
         'Noodlehaus\Parser\Ini',
         'Noodlehaus\Parser\Json',
         'Noodlehaus\Parser\Xml',
-        'Noodlehaus\Parser\Yaml'
+        'Noodlehaus\Parser\Yaml',
+        'Noodlehaus\Parser\Properties'
     ];
 
     /**

--- a/src/Parser/Properties.php
+++ b/src/Parser/Properties.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Noodlehaus\Parser;
+
+use Noodlehaus\Exception\ParseException;
+
+/**
+ * Properties parser.
+ *
+ * @package    Config
+ * @author     Jesus A. Domingo <jesus.domingo@gmail.com>
+ * @author     Hassan Khan <contact@hassankhan.me>
+ * @author     Filip Š <projects@filips.si>
+ * @author     Mark de Groot <mail@markdegroot.nl>
+ * @link       https://github.com/noodlehaus/config
+ * @license    MIT
+ */
+class Properties implements ParserInterface
+{
+    /**
+     * {@inheritdoc}
+     * Parses a Properties file as an array.
+     */
+    public function parseFile($filename)
+    {
+        return $this->parse(file_get_contents($filename));
+    }
+
+    /**
+     * {@inheritdoc}
+     * Parses a Properties string as an array.
+     */
+    public function parseString($config)
+    {
+        return $this->parse($config);
+    }
+
+    private function parse($txtProperties)
+    {
+        $result = [];
+
+        // first remove all escaped whitespace characters:
+        $txtProperties = preg_replace('/(?<!\\\\)\\\\[\r\n\t\f\v][ \r]*/', '', $txtProperties);
+
+        // next split all lines not starting with # or ! on characters = or : (unless escaped):
+        preg_match_all('/^([^#!].*)(?<!\\\\)[=:](.*)$/mU', $txtProperties, $matches, PREG_SET_ORDER, 0);
+
+        foreach ($matches as $match) {
+            $result[trim(stripslashes($match[1]))] = trim(stripslashes($match[2]));
+        }
+
+        return $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSupportedExtensions()
+    {
+        return ['properties'];
+    }
+}

--- a/src/Writer/Ini.php
+++ b/src/Writer/Ini.php
@@ -9,7 +9,6 @@ namespace Noodlehaus\Writer;
  * @author     Jesus A. Domingo <jesus.domingo@gmail.com>
  * @author     Hassan Khan <contact@hassankhan.me>
  * @author     Filip Š <projects@filips.si>
- * @author     Mark de Groot <mail@markdegroot.nl>
  * @link       https://github.com/noodlehaus/config
  * @license    MIT
  */
@@ -29,7 +28,7 @@ class Ini extends AbstractWriter
      */
     public static function getSupportedExtensions()
     {
-        return ['ini', 'properties'];
+        return ['ini'];
     }
 
     /**

--- a/src/Writer/Properties.php
+++ b/src/Writer/Properties.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Noodlehaus\Writer;
+
+/**
+ * Properties Writer.
+ *
+ * @package    Config
+ * @author     Jesus A. Domingo <jesus.domingo@gmail.com>
+ * @author     Hassan Khan <contact@hassankhan.me>
+ * @author     Filip Š <projects@filips.si>
+ * @author     Mark de Groot <mail@markdegroot.nl>
+ * @link       https://github.com/noodlehaus/config
+ * @license    MIT
+ */
+class Properties extends AbstractWriter
+{
+    /**
+     * {@inheritdoc}
+     * Writes an array to a Properties string.
+     */
+    public function toString($config, $pretty = true)
+    {
+        return $this->toProperties($config);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSupportedExtensions()
+    {
+        return ['properties'];
+    }
+
+    /**
+     * Converts array to Properties string.
+     * @param array $arr    Array to be converted
+     *
+     * @return string Converted array as Properties
+     */
+    protected function toProperties(array $arr)
+    {
+        $converted = '';
+
+        foreach ($arr as $key => $value) {
+            if (is_array($value)) {
+                continue;
+            }
+
+            // Escape all space, ; and = characters in the key:
+            $key = addcslashes($key, ' :=');
+
+            // Escape all backslashes and newlines in the value:
+            $value = preg_replace('/([\r\n\t\f\v\\\])/', '\\\$1', $value);
+
+            $converted .= $key.' = '.$value.PHP_EOL;
+        }
+
+        return $converted;
+    }
+}

--- a/tests/Parser/PropertiesTest.php
+++ b/tests/Parser/PropertiesTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Noodlehaus\Parser\Test;
+
+use Noodlehaus\Parser\Properties;
+use PHPUnit\Framework\TestCase;
+
+class PropertiesTest extends TestCase
+{
+    /**
+     * @var Properties
+     */
+    protected $properties;
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        $this->properties = new Properties();
+    }
+
+    /**
+     * Tears down the fixture, for example, closes a network connection.
+     * This method is called after a test is executed.
+     */
+    protected function tearDown()
+    {
+    }
+
+    /**
+     * @covers Noodlehaus\Parser\Properties::getSupportedExtensions()
+     */
+    public function testGetSupportedExtensions()
+    {
+        $expected = ['properties'];
+        $actual = $this->properties->getSupportedExtensions();
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @covers Noodlehaus\Parser\Properties::parseFile()
+     * @covers Noodlehaus\Parser\Properties::parseString()
+     * @covers Noodlehaus\Parser\Properties::parse()
+     */
+    public function testLoadProperties()
+    {
+        $config = $this->properties->parseFile(__DIR__.'/../mocks/pass/config.properties');
+
+        $this->assertEquals('https://en.wikipedia.org/', @$config['website']);
+        $this->assertEquals('English', @$config['language']);
+        $this->assertEquals('Welcome to Wikipedia!', @$config['message']);
+        $this->assertEquals('valueOverOneLine\\', @$config['key']);
+        $this->assertEquals('This is the value that could be looked up with the key "key with spaces".', @$config['key with spaces']);
+        $this->assertEquals('This is the value for the key "key:with=colonAndEqualsSign"', @$config['key:with=colonAndEqualsSign']);
+        $this->assertEquals('c:\\wiki\\templates', @$config['path']);
+    }
+
+    /**
+     * @covers Noodlehaus\Parser\Ini::parseFile()
+     * @covers Noodlehaus\Parser\Ini::parse()
+     */
+    public function testLoadInvalidIniGBH()
+    {
+        $config = $this->properties->parseFile(__DIR__.'/../mocks/fail/error.properties');
+
+        $this->assertEmpty($config);
+    }
+}

--- a/tests/Writer/IniTest.php
+++ b/tests/Writer/IniTest.php
@@ -56,7 +56,7 @@ class IniTest extends TestCase
      */
     public function testGetSupportedExtensions()
     {
-        $expected = ['ini', 'properties'];
+        $expected = ['ini'];
         $actual = $this->writer->getSupportedExtensions();
         $this->assertEquals($expected, $actual);
     }

--- a/tests/Writer/PropertiesTest.php
+++ b/tests/Writer/PropertiesTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Noodlehaus\Writer\Test;
+
+use Noodlehaus\Writer\Properties;
+use PHPUnit\Framework\TestCase;
+
+class PropertiesTest extends TestCase
+{
+    /**
+     * @var Properties
+     */
+    protected $writer;
+
+    /**
+     * @var string
+     */
+    protected $temp_file;
+
+    /**
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        $this->writer = new Properties();
+        $this->temp_file = tempnam(sys_get_temp_dir(), 'config.properties');
+        $this->data = [
+            'website' => 'https://en.wikipedia.org/',
+            'language' => 'English',
+            'message' => "Welcome to \nWikipedia!",
+            'key' => 'valueOverOneLine\\',
+            'key with spaces' => 'This is the value that could be looked up with the key "key with spaces".',
+            'key:with=colonAndEqualsSign' => 'This is the value for the key "key:with=colonAndEqualsSign"',
+            'path' => 'c:\wiki\templates',
+        ];
+    }
+
+    /**
+     * Tears down the fixture, for example, closes a network connection.
+     * This method is called after a test is executed.
+     */
+    protected function tearDown()
+    {
+        unlink($this->temp_file);
+    }
+
+    /**
+     * @covers Noodlehaus\Writer\Properties::getSupportedExtensions()
+     */
+    public function testGetSupportedExtensions()
+    {
+        $expected = ['properties'];
+        $actual = $this->writer->getSupportedExtensions();
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @covers Noodlehaus\Writer\Properties::toString()
+     * @covers Noodlehaus\Writer\Properties::toProperties()
+     */
+    public function testEncodeProperties()
+    {
+        $actual = $this->writer->toString($this->data);
+        $expected = <<< 'EOD'
+website = https://en.wikipedia.org/
+language = English
+message = Welcome to \
+Wikipedia!
+key = valueOverOneLine\\
+key\ with\ spaces = This is the value that could be looked up with the key "key with spaces".
+key\:with\=colonAndEqualsSign = This is the value for the key "key:with=colonAndEqualsSign"
+path = c:\\wiki\\templates
+
+EOD;
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @covers Noodlehaus\Writer\Properties::toString()
+     * @covers Noodlehaus\Writer\Properties::toFile()
+     * @covers Noodlehaus\Writer\Properties::toProperties()
+     */
+    public function testWriteProperties()
+    {
+        $this->writer->toFile($this->data, $this->temp_file);
+
+        $this->assertFileExists($this->temp_file);
+        $this->assertFileEquals(__DIR__.'/../mocks/pass/config1.properties', $this->temp_file);
+    }
+
+    /**
+     * @covers Noodlehaus\Writer\Properties::toString()
+     * @covers Noodlehaus\Writer\Properties::toFile()
+     * @covers Noodlehaus\Writer\Properties::toProperties()
+     * @expectedException        Noodlehaus\Exception\WriteException
+     * @expectedExceptionMessage There was an error writing the file
+     */
+    public function testUnwritableFile()
+    {
+        chmod($this->temp_file, 0444);
+
+        $this->writer->toFile($this->data, $this->temp_file);
+    }
+}

--- a/tests/mocks/fail/error.properties
+++ b/tests/mocks/fail/error.properties
@@ -1,0 +1,1 @@
+unparsable content

--- a/tests/mocks/pass/config.properties
+++ b/tests/mocks/pass/config.properties
@@ -1,0 +1,23 @@
+# You are reading the ".properties" entry.
+! The exclamation mark can also mark text as comments.
+# The key characters =, and : should be written with
+# a preceding backslash to ensure that they are properly loaded.
+# However, there is no need to precede the value characters =, and : by a backslash.
+website = https://en.wikipedia.org/
+language = English
+# The backslash below tells the application to continue reading
+# the value onto the next line.
+message = Welcome to \
+          Wikipedia!
+# But if the number of backslashes at the end of the line is even, the next line is not included in the value. In the following example, the value for "key" is "valueOverOneLine\"
+key = valueOverOneLine\\
+# This line is not included in the value for "key"
+# Add spaces to the key
+key\ with\ spaces = This is the value that could be looked up with the key "key with spaces".
+# The characters = and : in the key must be escaped as well:
+key\:with\=colonAndEqualsSign = This is the value for the key "key:with=colonAndEqualsSign"
+# Unicode
+tab : \u0009
+# If you want your property to include a backslash, it should be escaped by another backslash
+path=c:\\wiki\\templates
+# However, some editors will handle this automatically

--- a/tests/mocks/pass/config1.properties
+++ b/tests/mocks/pass/config1.properties
@@ -1,0 +1,8 @@
+website = https://en.wikipedia.org/
+language = English
+message = Welcome to \
+Wikipedia!
+key = valueOverOneLine\\
+key\ with\ spaces = This is the value that could be looked up with the key "key with spaces".
+key\:with\=colonAndEqualsSign = This is the value for the key "key:with=colonAndEqualsSign"
+path = c:\\wiki\\templates


### PR DESCRIPTION
Added support for Java properties files. 

Properties files are close to ini files, but as @DavidePastore [pointed out](https://github.com/hassankhan/config/pull/125#issuecomment-538640875), not completely the same. That's why I've written a dedicated parser and writer.