### PR TITLE
Fixed typehint on Xml parser, parse method

### DIFF
--- a/src/Parser/Xml.php
+++ b/src/Parser/Xml.php
@@ -46,7 +46,7 @@ class Xml implements ParserInterface
     /**
      * Completes parsing of XML data
      *
-     * @param  array $data
+     * @param  \SimpleXMLElement|null $data
      * @param  string $filename
      *
      * @return array|null


### PR DESCRIPTION
Hi,
The method `parse` is always called by using the result of `simplexml_load_string` which is `SimpleXMLElement` and not an array.
