### PR TITLE
Move to GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,8 +23,13 @@ jobs:
 
       - name: Install dependencies
         run: composer install --no-interaction --no-progress --prefer-dist
-
+      
       - name: PHP Unit tests
+        if: ${{ matrix.php-versions != '7.3' }}
+        run: vendor/bin/phpunit
+
+      - name: PHP Unit tests generating coverage data
+        if: ${{ matrix.php-versions == '7.3' }}
         run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
       
       - name: Upload code coverage data

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
         run: php -v
 
       - name: Install dependencies
-        run: composer install --no-interaction --no-progress --no-suggest --prefer-dist
+        run: composer install --no-interaction --no-progress --prefer-dist
 
       - name: PHP Unit tests
         run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,35 @@
+name: Continuous Integration
+
+on: [push, pull_request]
+
+jobs:
+  quality:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        # TODO Add 8.0 and 8.1 versions as well
+        php-versions: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+            php-version: ${{ matrix.php-versions }}
+      
+      - name: Check PHP Version
+        run: php -v
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --no-suggest --prefer-dist
+
+      - name: PHP Unit tests
+        run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
+      
+      - name: Upload code coverage data
+        if: ${{ matrix.php-versions }} == '7.3'
+        run: php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,9 +20,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
             php-version: ${{ matrix.php-versions }}
-      
-      - name: Check PHP Version
-        run: php -v
 
       - name: Install dependencies
         run: composer install --no-interaction --no-progress --prefer-dist
@@ -31,5 +28,5 @@ jobs:
         run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
       
       - name: Upload code coverage data
-        if: ${{ matrix.php-versions }} == '7.3'
+        if: ${{ matrix.php-versions == '7.3' }}
         run: php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -19,7 +19,6 @@ checks:
 tools:
     external_code_coverage:
         timeout: 600
-        runs: 3
     php_analyzer: true
     php_code_coverage: false
     php_code_sniffer:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest version][ico-version]][link-packagist]
 [![Software License][ico-license]][link-license]
-[![Build Status][ico-travis]][link-travis]
+[![Build Status][ico-gh-actions]][link-gh-actions]
 [![Coverage Status][ico-scrutinizer]][link-scrutinizer]
 [![Quality Score][ico-code-quality]][link-code-quality]
 [![Total Downloads][ico-downloads]][link-downloads]
@@ -260,7 +260,7 @@ The MIT License (MIT). Please see [License File](LICENSE.md) for more informatio
 
 [ico-version]: https://img.shields.io/packagist/v/hassankhan/config.svg?style=flat-square
 [ico-license]: https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square
-[ico-travis]: https://img.shields.io/travis/hassankhan/config/master.svg?style=flat-square
+[ico-gh-actions]: https://img.shields.io/github/workflow/status/hassankhan/config/Continuous%20Integration/master?style=flat-square
 [ico-scrutinizer]: https://img.shields.io/scrutinizer/coverage/g/hassankhan/config.svg?style=flat-square
 [ico-code-quality]: https://img.shields.io/scrutinizer/g/hassankhan/config.svg?style=flat-square
 [ico-downloads]: https://img.shields.io/packagist/dt/hassankhan/config.svg?style=flat-square
@@ -268,7 +268,7 @@ The MIT License (MIT). Please see [License File](LICENSE.md) for more informatio
 
 [link-packagist]: https://packagist.org/packages/hassankhan/config
 [link-license]: http://hassankhan.mit-license.org
-[link-travis]: https://travis-ci.org/hassankhan/config
+[link-gh-actions]: https://github.com/hassankhan/config/actions?query=workflow%3A%22Continuous+Integration%22+branch%3Amaster
 [link-scrutinizer]: https://scrutinizer-ci.com/g/hassankhan/config/code-structure
 [link-code-quality]: https://scrutinizer-ci.com/g/hassankhan/config
 [link-downloads]: https://packagist.org/packages/hassankhan/config

--- a/tests/Parser/IniTest.php
+++ b/tests/Parser/IniTest.php
@@ -57,24 +57,16 @@ class IniTest extends TestCase
     /**
      * @covers                   Noodlehaus\Parser\Ini::parseString()
      * @covers                   Noodlehaus\Parser\Ini::parse()
-     * @expectedException        Noodlehaus\Exception\ParseException
-     * @expectedExceptionMessage syntax error, unexpected $end, expecting ']'
-     * @requires PHP < 7.4
      */
     public function testLoadInvalidIni()
     {
-        $this->ini->parseString(file_get_contents(__DIR__ . '/../mocks/fail/error.ini'));
-    }
-
-    /**
-     * @covers                   Noodlehaus\Parser\Ini::parseString()
-     * @covers                   Noodlehaus\Parser\Ini::parse()
-     * @expectedException        Noodlehaus\Exception\ParseException
-     * @expectedExceptionMessage syntax error, unexpected end of file, expecting ']' in Unknown on line 1
-     * @requires PHP >= 7.4
-     */
-    public function testLoadInvalidIniForPhp74()
-    {
+        if (PHP_VERSION_ID < 70400 && PHP_VERSION_ID >= 50500) {
+            $this->expectException(\Noodlehaus\Exception\ParseException::class);
+            $this->expectExceptionMessage("syntax error, unexpected \$end, expecting ']'");
+        } else {
+            $this->expectExceptionMessage("syntax error, unexpected end of file, expecting ']' in Unknown on line 1");
+        }
+        
         $this->ini->parseString(file_get_contents(__DIR__ . '/../mocks/fail/error.ini'));
     }
 

--- a/tests/Parser/IniTest.php
+++ b/tests/Parser/IniTest.php
@@ -61,10 +61,18 @@ class IniTest extends TestCase
     public function testLoadInvalidIni()
     {
         if (PHP_VERSION_ID < 70400 && PHP_VERSION_ID >= 50500) {
-            $this->expectException(\Noodlehaus\Exception\ParseException::class);
-            $this->expectExceptionMessage("syntax error, unexpected \$end, expecting ']'");
+            $exceptionMessage = "syntax error, unexpected \$end, expecting ']'";
         } else {
-            $this->expectExceptionMessage("syntax error, unexpected end of file, expecting ']' in Unknown on line 1");
+            $exceptionMessage = "syntax error, unexpected end of file, expecting ']' in Unknown on line 1";
+        }
+
+        if (PHP_VERSION_ID < 50600 && PHP_VERSION_ID >= 50500) {
+            $this->setExpectedException(
+                '\Noodlehaus\Exception\ParseException', $exceptionMessage
+            );
+        } else {
+            $this->expectException(\Noodlehaus\Exception\ParseException::class);
+            $this->expectExceptionMessage($exceptionMessage);
         }
         
         $this->ini->parseString(file_get_contents(__DIR__ . '/../mocks/fail/error.ini'));

--- a/tests/Parser/IniTest.php
+++ b/tests/Parser/IniTest.php
@@ -59,8 +59,21 @@ class IniTest extends TestCase
      * @covers                   Noodlehaus\Parser\Ini::parse()
      * @expectedException        Noodlehaus\Exception\ParseException
      * @expectedExceptionMessage syntax error, unexpected $end, expecting ']'
+     * @requires PHP < 7.4
      */
     public function testLoadInvalidIni()
+    {
+        $this->ini->parseString(file_get_contents(__DIR__ . '/../mocks/fail/error.ini'));
+    }
+
+    /**
+     * @covers                   Noodlehaus\Parser\Ini::parseString()
+     * @covers                   Noodlehaus\Parser\Ini::parse()
+     * @expectedException        Noodlehaus\Exception\ParseException
+     * @expectedExceptionMessage syntax error, unexpected end of file, expecting ']' in Unknown on line 1
+     * @requires PHP >= 7.4
+     */
+    public function testLoadInvalidIniForPhp74()
     {
         $this->ini->parseString(file_get_contents(__DIR__ . '/../mocks/fail/error.ini'));
     }


### PR DESCRIPTION
Closed #136 and closed #132.

Things to do:
- [x] ensure same versions are being tested;
- [x] ensure coverage is correctly uploaded to scrutinizer-ci only for PHP 7.3;
- [x] replace Travis badge with GitHub Actions one on README.md.