### PR TITLE
Let assertEquals change into assertSame

### DIFF
--- a/tests/AbstractConfigTest.php
+++ b/tests/AbstractConfigTest.php
@@ -52,8 +52,8 @@ class AbstractConfigTest extends TestCase
                 'port'    => 80,
             ]
         );
-        $this->assertEquals('localhost', $config->get('host'));
-        $this->assertEquals(80, $config->get('port'));
+        $this->assertSame('localhost', $config->get('host'));
+        $this->assertSame(80, $config->get('port'));
     }
 
     /**
@@ -61,7 +61,7 @@ class AbstractConfigTest extends TestCase
      */
     public function testGet()
     {
-        $this->assertEquals('localhost', $this->config->get('host'));
+        $this->assertSame('localhost', $this->config->get('host'));
     }
 
     /**
@@ -69,7 +69,7 @@ class AbstractConfigTest extends TestCase
      */
     public function testGetWithDefaultValue()
     {
-        $this->assertEquals(128, $this->config->get('ttl', 128));
+        $this->assertSame(128, $this->config->get('ttl', 128));
     }
 
     /**
@@ -77,7 +77,7 @@ class AbstractConfigTest extends TestCase
      */
     public function testGetNestedKey()
     {
-        $this->assertEquals('configuration', $this->config->get('application.name'));
+        $this->assertSame('configuration', $this->config->get('application.name'));
     }
 
     /**
@@ -85,7 +85,7 @@ class AbstractConfigTest extends TestCase
      */
     public function testGetNestedKeyWithDefaultValue()
     {
-        $this->assertEquals(128, $this->config->get('application.ttl', 128));
+        $this->assertSame(128, $this->config->get('application.ttl', 128));
     }
 
     /**
@@ -110,7 +110,7 @@ class AbstractConfigTest extends TestCase
     public function testGetReturnsArray()
     {
         $this->assertArrayHasKey('name', $this->config->get('application'));
-        $this->assertEquals('configuration', $this->config->get('application.name'));
+        $this->assertSame('configuration', $this->config->get('application.name'));
         $this->assertCount(3, $this->config->get('application'));
     }
 
@@ -120,7 +120,7 @@ class AbstractConfigTest extends TestCase
     public function testSet()
     {
         $this->config->set('region', 'apac');
-        $this->assertEquals('apac', $this->config->get('region'));
+        $this->assertSame('apac', $this->config->get('region'));
     }
 
     /**
@@ -129,7 +129,7 @@ class AbstractConfigTest extends TestCase
     public function testSetNestedKey()
     {
         $this->config->set('location.country', 'Singapore');
-        $this->assertEquals('Singapore', $this->config->get('location.country'));
+        $this->assertSame('Singapore', $this->config->get('location.country'));
     }
 
     /**
@@ -142,7 +142,7 @@ class AbstractConfigTest extends TestCase
             'name' => 'mydatabase'
         ]);
         $this->assertIsArray($this->config->get('database'));
-        $this->assertEquals('localhost', $this->config->get('database.host'));
+        $this->assertSame('localhost', $this->config->get('database.host'));
     }
 
     /**
@@ -160,7 +160,7 @@ class AbstractConfigTest extends TestCase
             'host' => '127.0.0.1',
             'name' => 'mydatabase'
         ];
-        $this->assertEquals($expected, $this->config->get('database'));
+        $this->assertSame($expected, $this->config->get('database'));
 
         $this->config->set('config', [
             'database' => [
@@ -178,13 +178,13 @@ class AbstractConfigTest extends TestCase
                 'name' => 'mydatabase'
             ]
         ];
-        $this->assertEquals($expected, $this->config->get('config'));
+        $this->assertSame($expected, $this->config->get('config'));
 
         $expected = [
             'host' => '127.0.0.1',
             'name' => 'mydatabase'
         ];
-        $this->assertEquals($expected, $this->config->get('config.database'));
+        $this->assertSame($expected, $this->config->get('config.database'));
     }
 
     /**
@@ -207,8 +207,8 @@ class AbstractConfigTest extends TestCase
           'host' => '127.0.0.1',
           'name' => 'mynewdatabase'
         ]);
-        $this->assertEquals('127.0.0.1', $this->config->get('config.database.host'));
-        $this->assertEquals('mynewdatabase', $this->config->get('config.database.name'));
+        $this->assertSame('127.0.0.1', $this->config->get('config.database.host'));
+        $this->assertSame('mynewdatabase', $this->config->get('config.database.name'));
     }
 
     /**
@@ -221,7 +221,7 @@ class AbstractConfigTest extends TestCase
             'name' => 'mydatabase'
         ]);
         $this->assertIsArray($this->config->get('database'));
-        $this->assertEquals('localhost', $this->config->get('database.host'));
+        $this->assertSame('localhost', $this->config->get('database.host'));
         $this->config->set('database.host', null);
         $this->assertNull($this->config->get('database.host'));
         $this->config->set('database', null);
@@ -278,7 +278,7 @@ class AbstractConfigTest extends TestCase
             ],
             'user' => null,
         ];
-        $this->assertEquals($all, $this->config->all());
+        $this->assertSame($all, $this->config->all());
     }
 
     /**
@@ -296,7 +296,7 @@ class AbstractConfigTest extends TestCase
         $this->config->get('host');
         $this->config->merge($remote);
 
-        $this->assertEquals('127.0.0.1', $this->config['host']);
+        $this->assertSame('127.0.0.1', $this->config['host']);
     }
 
     /**
@@ -304,7 +304,7 @@ class AbstractConfigTest extends TestCase
      */
     public function testOffsetGet()
     {
-        $this->assertEquals('localhost', $this->config['host']);
+        $this->assertSame('localhost', $this->config['host']);
     }
 
     /**
@@ -312,7 +312,7 @@ class AbstractConfigTest extends TestCase
      */
     public function testOffsetGetNestedKey()
     {
-        $this->assertEquals('configuration', $this->config['application.name']);
+        $this->assertSame('configuration', $this->config['application.name']);
     }
 
     /**
@@ -337,7 +337,7 @@ class AbstractConfigTest extends TestCase
     public function testOffsetSet()
     {
         $this->config['newkey'] = 'newvalue';
-        $this->assertEquals('newvalue', $this->config['newkey']);
+        $this->assertSame('newvalue', $this->config['newkey']);
     }
 
     /**
@@ -356,17 +356,17 @@ class AbstractConfigTest extends TestCase
     {
         /* Reset to the beginning of the test config */
         $this->config->rewind();
-        $this->assertEquals($this->config['host'], $this->config->current());
+        $this->assertSame($this->config['host'], $this->config->current());
 
         /* Step through each of the other elements of the test config */
         $this->config->next();
-        $this->assertEquals($this->config['port'], $this->config->current());
+        $this->assertSame($this->config['port'], $this->config->current());
         $this->config->next();
-        $this->assertEquals($this->config['servers'], $this->config->current());
+        $this->assertSame($this->config['servers'], $this->config->current());
         $this->config->next();
-        $this->assertEquals($this->config['application'], $this->config->current());
+        $this->assertSame($this->config['application'], $this->config->current());
         $this->config->next();
-        $this->assertEquals($this->config['user'], $this->config->current());
+        $this->assertSame($this->config['user'], $this->config->current());
 
         /* Step beyond the end and confirm the result */
         $this->config->next();
@@ -380,17 +380,17 @@ class AbstractConfigTest extends TestCase
     {
         /* Reset to the beginning of the test config */
         $this->config->rewind();
-        $this->assertEquals('host', $this->config->key());
+        $this->assertSame('host', $this->config->key());
 
         /* Step through each of the other elements of the test config */
         $this->config->next();
-        $this->assertEquals('port', $this->config->key());
+        $this->assertSame('port', $this->config->key());
         $this->config->next();
-        $this->assertEquals('servers', $this->config->key());
+        $this->assertSame('servers', $this->config->key());
         $this->config->next();
-        $this->assertEquals('application', $this->config->key());
+        $this->assertSame('application', $this->config->key());
         $this->config->next();
-        $this->assertEquals('user', $this->config->key());
+        $this->assertSame('user', $this->config->key());
 
         /* Step beyond the end and confirm the result */
         $this->config->next();
@@ -406,10 +406,10 @@ class AbstractConfigTest extends TestCase
         $this->config->rewind();
 
         /* Step through each of the other elements of the test config */
-        $this->assertEquals($this->config['port'], $this->config->next());
-        $this->assertEquals($this->config['servers'], $this->config->next());
-        $this->assertEquals($this->config['application'], $this->config->next());
-        $this->assertEquals($this->config['user'], $this->config->next());
+        $this->assertSame($this->config['port'], $this->config->next());
+        $this->assertSame($this->config['servers'], $this->config->next());
+        $this->assertSame($this->config['application'], $this->config->next());
+        $this->assertSame($this->config['user'], $this->config->next());
 
         /* Step beyond the end and confirm the result */
         $this->assertFalse($this->config->next());
@@ -423,10 +423,10 @@ class AbstractConfigTest extends TestCase
         /* Rewind from somewhere out in the array */
         $this->config->next();
         $this->config->next();
-        $this->assertEquals($this->config['host'], $this->config->rewind());
+        $this->assertSame($this->config['host'], $this->config->rewind());
 
         /* Rewind again from the beginning of the array */
-        $this->assertEquals($this->config['host'], $this->config->rewind());
+        $this->assertSame($this->config['host'], $this->config->rewind());
     }
 
     /**
@@ -482,8 +482,8 @@ class AbstractConfigTest extends TestCase
         $idxConfig = 0;
 
         foreach ($this->config as $configKey => $configValue) {
-            $this->assertEquals($expectedKeys[$idxConfig], $configKey);
-            $this->assertEquals($expectedValues[$idxConfig], $configValue);
+            $this->assertSame($expectedKeys[$idxConfig], $configKey);
+            $this->assertSame($expectedValues[$idxConfig], $configValue);
             $idxConfig++;
         }
     }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -82,7 +82,7 @@ class ConfigTest extends TestCase
         $expected = 'localhost';
         $actual   = $config->get('host');
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -101,7 +101,7 @@ class ConfigTest extends TestCase
         $expected = 'localhost';
         $actual   = $config->get('host');
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -119,7 +119,7 @@ class ConfigTest extends TestCase
         $expected = 'localhost';
         $actual   = $config->get('host');
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -137,7 +137,7 @@ class ConfigTest extends TestCase
         $expected = 'localhost';
         $actual   = $config->get('host');
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -154,7 +154,7 @@ class ConfigTest extends TestCase
         $expected = 'localhost';
         $actual   = $config->get('host');
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -171,7 +171,7 @@ class ConfigTest extends TestCase
         $expected = 'localhost';
         $actual   = $config->get('host');
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -188,7 +188,7 @@ class ConfigTest extends TestCase
         $expected = 'localhost';
         $actual   = $config->get('host');
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -205,7 +205,7 @@ class ConfigTest extends TestCase
         $expected = [];
         $actual   = $config->all();
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -221,7 +221,7 @@ class ConfigTest extends TestCase
         $expected = 'localhost';
         $actual   = $config->get('host');
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -236,7 +236,7 @@ class ConfigTest extends TestCase
         $expected = 'localhost';
         $actual   = $config->get('host');
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**

--- a/tests/Parser/IniTest.php
+++ b/tests/Parser/IniTest.php
@@ -31,7 +31,7 @@ class IniTest extends TestCase
     {
         $expected = ['ini'];
         $actual   = $this->ini->getSupportedExtensions();
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -75,11 +75,11 @@ class IniTest extends TestCase
         $file = $this->ini->parseFile(__DIR__ . '/../mocks/pass/config.ini');
         $string = $this->ini->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config.ini'));
 
-        $this->assertEquals('localhost', $file['host']);
-        $this->assertEquals('80', $file['port']);
+        $this->assertSame('localhost', $file['host']);
+        $this->assertSame('80', $file['port']);
 
-        /*$this->assertEquals('localhost', $string['host']);
-        $this->assertEquals('80', $string['port']);*/
+        /*$this->assertSame('localhost', $string['host']);
+        $this->assertSame(80, $string['port']);*/
     }
 
     /**
@@ -95,12 +95,12 @@ class IniTest extends TestCase
 
         $expected = ['host1', 'host2', 'host3'];
 
-        $this->assertEquals($expected, $file['network']['group']['servers']);
-        $this->assertEquals('localhost', $file['network']['http']['host']);
-        $this->assertEquals('80', $file['network']['http']['port']);
+        $this->assertSame($expected, $file['network']['group']['servers']);
+        $this->assertSame('localhost', $file['network']['http']['host']);
+        $this->assertSame('80', $file['network']['http']['port']);
 
-        $this->assertEquals($expected, $string['network']['group']['servers']);
-        $this->assertEquals('localhost', $string['network']['http']['host']);
-        $this->assertEquals('80', $string['network']['http']['port']);
+        $this->assertSame($expected, $string['network']['group']['servers']);
+        $this->assertSame('localhost', $string['network']['http']['host']);
+        $this->assertSame('80', $string['network']['http']['port']);
     }
 }

--- a/tests/Parser/JsonTest.php
+++ b/tests/Parser/JsonTest.php
@@ -31,7 +31,7 @@ class JsonTest extends TestCase
     {
         $expected = ['json'];
         $actual   = $this->json->getSupportedExtensions();
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -55,10 +55,10 @@ class JsonTest extends TestCase
         $file = $this->json->parseFile(__DIR__ . '/../mocks/pass/config.json');
         $string = $this->json->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config.json'));
 
-        $this->assertEquals('localhost', $file['host']);
-        $this->assertEquals('80', $file['port']);
+        $this->assertSame('localhost', $file['host']);
+        $this->assertSame(80, $file['port']);
 
-        $this->assertEquals('localhost', $string['host']);
-        $this->assertEquals('80', $string['port']);
+        $this->assertSame('localhost', $string['host']);
+        $this->assertSame(80, $string['port']);
     }
 }

--- a/tests/Parser/PhpTest.php
+++ b/tests/Parser/PhpTest.php
@@ -31,7 +31,7 @@ class PhpTest extends TestCase
     {
         $expected = ['php'];
         $actual   = $this->php->getSupportedExtensions();
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -77,11 +77,11 @@ class PhpTest extends TestCase
         $file = $this->php->parseFile(__DIR__ . '/../mocks/pass/config.php');
         $string = $this->php->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config.php'));
 
-        $this->assertEquals('localhost', $file['host']);
-        $this->assertEquals('80', $file['port']);
+        $this->assertSame('localhost', $file['host']);
+        $this->assertSame(80, $file['port']);
 
-        $this->assertEquals('localhost', $string['host']);
-        $this->assertEquals('80', $string['port']);
+        $this->assertSame('localhost', $string['host']);
+        $this->assertSame(80, $string['port']);
     }
 
     /**
@@ -95,11 +95,11 @@ class PhpTest extends TestCase
         $file = $this->php->parseFile(__DIR__ . '/../mocks/pass/config-exec.php');
         $string = $this->php->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config-exec.php'));
 
-        $this->assertEquals('localhost', $file['host']);
-        $this->assertEquals('80', $file['port']);
+        $this->assertSame('localhost', $file['host']);
+        $this->assertSame(80, $file['port']);
 
-        $this->assertEquals('localhost', $string['host']);
-        $this->assertEquals('80', $string['port']);
+        $this->assertSame('localhost', $string['host']);
+        $this->assertSame(80, $string['port']);
     }
 
     /**
@@ -113,10 +113,10 @@ class PhpTest extends TestCase
         $file = $this->php->parseFile(__DIR__ . '/../mocks/pass/config-var.php');
         $string = $this->php->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config-var.php'));
 
-        $this->assertEquals('localhost', $file['host']);
-        $this->assertEquals('80', $file['port']);
+        $this->assertSame('localhost', $file['host']);
+        $this->assertSame(80, $file['port']);
 
-        $this->assertEquals('localhost', $string['host']);
-        $this->assertEquals('80', $string['port']);
+        $this->assertSame('localhost', $string['host']);
+        $this->assertSame(80, $string['port']);
     }
 }

--- a/tests/Parser/PropertiesTest.php
+++ b/tests/Parser/PropertiesTest.php
@@ -28,7 +28,7 @@ class PropertiesTest extends TestCase
     {
         $expected = ['properties'];
         $actual = $this->properties->getSupportedExtensions();
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -40,13 +40,13 @@ class PropertiesTest extends TestCase
     {
         $config = $this->properties->parseFile(__DIR__.'/../mocks/pass/config.properties');
 
-        $this->assertEquals('https://en.wikipedia.org/', @$config['website']);
-        $this->assertEquals('English', @$config['language']);
-        $this->assertEquals('Welcome to Wikipedia!', @$config['message']);
-        $this->assertEquals('valueOverOneLine\\', @$config['key']);
-        $this->assertEquals('This is the value that could be looked up with the key "key with spaces".', @$config['key with spaces']);
-        $this->assertEquals('This is the value for the key "key:with=colonAndEqualsSign"', @$config['key:with=colonAndEqualsSign']);
-        $this->assertEquals('c:\\wiki\\templates', @$config['path']);
+        $this->assertSame('https://en.wikipedia.org/', @$config['website']);
+        $this->assertSame('English', @$config['language']);
+        $this->assertSame('Welcome to Wikipedia!', @$config['message']);
+        $this->assertSame('valueOverOneLine\\', @$config['key']);
+        $this->assertSame('This is the value that could be looked up with the key "key with spaces".', @$config['key with spaces']);
+        $this->assertSame('This is the value for the key "key:with=colonAndEqualsSign"', @$config['key:with=colonAndEqualsSign']);
+        $this->assertSame('c:\\wiki\\templates', @$config['path']);
     }
 
     /**

--- a/tests/Parser/SerializeTest.php
+++ b/tests/Parser/SerializeTest.php
@@ -31,7 +31,7 @@ class SerializeTest extends TestCase
     {
         $expected = ['txt'];
         $actual   = $this->serialize->getSupportedExtensions();
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -55,10 +55,10 @@ class SerializeTest extends TestCase
         $file = $this->serialize->parseFile(__DIR__ . '/../mocks/pass/config.txt');
         $string = $this->serialize->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config.txt'));
 
-        $this->assertEquals('localhost', $file['host']);
-        $this->assertEquals('80', $file['port']);
+        $this->assertSame('localhost', $file['host']);
+        $this->assertSame(80, $file['port']);
 
-        $this->assertEquals('localhost', $string['host']);
-        $this->assertEquals('80', $string['port']);
+        $this->assertSame('localhost', $string['host']);
+        $this->assertSame(80, $string['port']);
     }
 }

--- a/tests/Parser/XmlTest.php
+++ b/tests/Parser/XmlTest.php
@@ -31,7 +31,7 @@ class XmlTest extends TestCase
     {
         $expected = ['xml'];
         $actual   = $this->xml->getSupportedExtensions();
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -55,10 +55,10 @@ class XmlTest extends TestCase
         $file = $this->xml->parseFile(__DIR__ . '/../mocks/pass/config.xml');
         $string = $this->xml->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config.xml'));
 
-        $this->assertEquals('localhost', $file['host']);
-        $this->assertEquals('80', $file['port']);
+        $this->assertSame('localhost', $file['host']);
+        $this->assertSame('80', $file['port']);
 
-        $this->assertEquals('localhost', $string['host']);
-        $this->assertEquals('80', $string['port']);
+        $this->assertSame('localhost', $string['host']);
+        $this->assertSame('80', $string['port']);
     }
 }

--- a/tests/Parser/YamlTest.php
+++ b/tests/Parser/YamlTest.php
@@ -31,7 +31,7 @@ class YamlTest extends TestCase
     {
         $expected = ['yaml', 'yml'];
         $actual   = $this->yaml->getSupportedExtensions();
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -63,8 +63,8 @@ class YamlTest extends TestCase
     public function testLoadYaml()
     {
         $actual = $this->yaml->parseFile(__DIR__ . '/../mocks/pass/config.yaml');
-        $this->assertEquals('localhost', $actual['host']);
-        $this->assertEquals('80', $actual['port']);
+        $this->assertSame('localhost', $actual['host']);
+        $this->assertSame(80, $actual['port']);
     }
 
     /**
@@ -73,8 +73,8 @@ class YamlTest extends TestCase
     public function testLoadYml()
     {
         $actual = $this->yaml->parseFile(__DIR__ . '/../mocks/pass/config.yml');
-        $this->assertEquals('localhost', $actual['host']);
-        $this->assertEquals('80', $actual['port']);
+        $this->assertSame('localhost', $actual['host']);
+        $this->assertSame(80, $actual['port']);
     }
 
     /**
@@ -83,7 +83,7 @@ class YamlTest extends TestCase
     public function testLoadYamlString()
     {
         $actual = $this->yaml->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config.yaml'));
-        $this->assertEquals('localhost', $actual['host']);
-        $this->assertEquals('80', $actual['port']);
+        $this->assertSame('localhost', $actual['host']);
+        $this->assertSame(80, $actual['port']);
     }
 }

--- a/tests/Writer/IniTest.php
+++ b/tests/Writer/IniTest.php
@@ -58,7 +58,7 @@ class IniTest extends TestCase
     {
         $expected = ['ini'];
         $actual = $this->writer->getSupportedExtensions();
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -77,7 +77,7 @@ name=config
 description=Config Reader and Writer
 
 EOD;
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**

--- a/tests/Writer/JsonTest.php
+++ b/tests/Writer/JsonTest.php
@@ -61,7 +61,7 @@ class JsonTest extends TestCase
     {
         $expected = ['json'];
         $actual = $this->writer->getSupportedExtensions();
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -72,7 +72,7 @@ class JsonTest extends TestCase
         $actual = $this->writer->toString($this->data, false);
         $expected = '{"application":{"name":"configuration","secret":"s3cr3t"},"host":"localhost","port":80,"servers":["host1","host2","host3"]}';
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**

--- a/tests/Writer/PropertiesTest.php
+++ b/tests/Writer/PropertiesTest.php
@@ -57,7 +57,7 @@ class PropertiesTest extends TestCase
     {
         $expected = ['properties'];
         $actual = $this->writer->getSupportedExtensions();
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -78,7 +78,7 @@ key\:with\=colonAndEqualsSign = This is the value for the key "key:with=colonAnd
 path = c:\\wiki\\templates
 
 EOD;
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**

--- a/tests/Writer/SerializeTest.php
+++ b/tests/Writer/SerializeTest.php
@@ -61,7 +61,7 @@ class SerializeTest extends TestCase
     {
         $expected = ['txt'];
         $actual = $this->writer->getSupportedExtensions();
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -72,7 +72,7 @@ class SerializeTest extends TestCase
         $actual = $this->writer->toString($this->data, false);
         $expected = 'a:4:{s:11:"application";a:2:{s:4:"name";s:13:"configuration";s:6:"secret";s:6:"s3cr3t";}s:4:"host";s:9:"localhost";s:4:"port";i:80;s:7:"servers";a:3:{i:0;s:5:"host1";i:1;s:5:"host2";i:2;s:5:"host3";}}';
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**

--- a/tests/Writer/XmlTest.php
+++ b/tests/Writer/XmlTest.php
@@ -61,7 +61,7 @@ class XmlTest extends TestCase
     {
         $expected = ['xml'];
         $actual = $this->writer->getSupportedExtensions();
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -76,7 +76,7 @@ class XmlTest extends TestCase
 <config><application><name>configuration</name><secret>s3cr3t</secret></application><host>localhost</host><port>80</port><servers><server1>host1</server1><server2>host2</server2><server3>host3</server3></servers></config>
 
 EOD;
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**

--- a/tests/Writer/YamlTest.php
+++ b/tests/Writer/YamlTest.php
@@ -61,7 +61,7 @@ class YamlTest extends TestCase
     {
         $expected = ['yaml'];
         $actual = $this->writer->getSupportedExtensions();
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -82,7 +82,7 @@ servers:
     - host3
 
 EOD;
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**


### PR DESCRIPTION
# Changed log

- Let the `assertEquals` change into `assertSame` and it can make assert equals strict.