### PR TITLE
Fix namespaces in tests & allow tests to run on PHP 8.2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,7 +11,7 @@ jobs:
         php-versions: ['7.4', '8.0', '8.1', '8.2']
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1', '8.2']
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:
       - uses: actions/checkout@v2

--- a/src/Config.php
+++ b/src/Config.php
@@ -5,7 +5,6 @@ namespace Noodlehaus;
 use Noodlehaus\Exception\FileNotFoundException;
 use Noodlehaus\Exception\UnsupportedFormatException;
 use Noodlehaus\Exception\EmptyDirectoryException;
-use InvalidArgumentException;
 use Noodlehaus\Parser\ParserInterface;
 use Noodlehaus\Writer\WriterInterface;
 

--- a/src/Parser/Ini.php
+++ b/src/Parser/Ini.php
@@ -44,7 +44,7 @@ class Ini implements ParserInterface
      * Completes parsing of INI data
      *
      * @param  array   $data
-     * @param  strring $filename
+     * @param  string $filename
      *
      * @throws ParseException If there is an error parsing the INI data
      */

--- a/src/Parser/Properties.php
+++ b/src/Parser/Properties.php
@@ -2,8 +2,6 @@
 
 namespace Noodlehaus\Parser;
 
-use Noodlehaus\Exception\ParseException;
-
 /**
  * Properties parser.
  *

--- a/tests/AbstractConfigTest.php
+++ b/tests/AbstractConfigTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Noodlehaus;
+namespace Noodlehaus\Test;
 
 use Noodlehaus\Test\Fixture\SimpleConfig;
 use PHPUnit\Framework\TestCase;
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 class AbstractConfigTest extends TestCase
 {
     /**
-     * @var Config
+     * @var \Noodlehaus\Config
      */
     protected $config;
 
@@ -41,8 +41,8 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::__construct()
-     * @covers Noodlehaus\AbstractConfig::getDefaults()
+     * @covers \Noodlehaus\AbstractConfig::__construct()
+     * @covers \Noodlehaus\AbstractConfig::getDefaults()
      */
     public function testDefaultOptionsSetOnInstantiation()
     {
@@ -57,7 +57,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::get()
+     * @covers \Noodlehaus\AbstractConfig::get()
      */
     public function testGet()
     {
@@ -65,7 +65,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::get()
+     * @covers \Noodlehaus\AbstractConfig::get()
      */
     public function testGetWithDefaultValue()
     {
@@ -73,7 +73,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::get()
+     * @covers \Noodlehaus\AbstractConfig::get()
      */
     public function testGetNestedKey()
     {
@@ -81,7 +81,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::get()
+     * @covers \Noodlehaus\AbstractConfig::get()
      */
     public function testGetNestedKeyWithDefaultValue()
     {
@@ -89,7 +89,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::get()
+     * @covers \Noodlehaus\AbstractConfig::get()
      */
     public function testGetNonexistentKey()
     {
@@ -97,7 +97,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::get()
+     * @covers \Noodlehaus\AbstractConfig::get()
      */
     public function testGetNonexistentNestedKey()
     {
@@ -105,7 +105,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::get()
+     * @covers \Noodlehaus\AbstractConfig::get()
      */
     public function testGetReturnsArray()
     {
@@ -115,7 +115,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::set()
+     * @covers \Noodlehaus\AbstractConfig::set()
      */
     public function testSet()
     {
@@ -124,7 +124,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::set()
+     * @covers \Noodlehaus\AbstractConfig::set()
      */
     public function testSetNestedKey()
     {
@@ -133,7 +133,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::set()
+     * @covers \Noodlehaus\AbstractConfig::set()
      */
     public function testSetArray()
     {
@@ -146,7 +146,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::set()
+     * @covers \Noodlehaus\AbstractConfig::set()
      */
     public function testCacheWithNestedArray()
     {
@@ -188,7 +188,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::set()
+     * @covers \Noodlehaus\AbstractConfig::set()
      */
     public function testCacheWithNestedMiddleArray()
     {
@@ -212,7 +212,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::set()
+     * @covers \Noodlehaus\AbstractConfig::set()
      */
     public function testSetAndUnsetArray()
     {
@@ -229,7 +229,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::has()
+     * @covers \Noodlehaus\AbstractConfig::has()
      */
     public function testHas()
     {
@@ -239,7 +239,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::has()
+     * @covers \Noodlehaus\AbstractConfig::has()
      */
     public function testHasNestedKey()
     {
@@ -250,7 +250,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::has()
+     * @covers \Noodlehaus\AbstractConfig::has()
      */
     public function testHasCache()
     {
@@ -259,7 +259,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::all()
+     * @covers \Noodlehaus\AbstractConfig::all()
      */
     public function testAll()
     {
@@ -282,7 +282,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::merge()
+     * @covers \Noodlehaus\AbstractConfig::merge()
      */
     public function testMerge()
     {
@@ -300,7 +300,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::offsetGet()
+     * @covers \Noodlehaus\AbstractConfig::offsetGet()
      */
     public function testOffsetGet()
     {
@@ -308,7 +308,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::offsetGet()
+     * @covers \Noodlehaus\AbstractConfig::offsetGet()
      */
     public function testOffsetGetNestedKey()
     {
@@ -316,7 +316,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::offsetExists()
+     * @covers \Noodlehaus\AbstractConfig::offsetExists()
      */
     public function testOffsetExists()
     {
@@ -324,7 +324,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::offsetExists()
+     * @covers \Noodlehaus\AbstractConfig::offsetExists()
      */
     public function testOffsetExistsReturnsFalseOnNonexistentKey()
     {
@@ -332,7 +332,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::offsetSet()
+     * @covers \Noodlehaus\AbstractConfig::offsetSet()
      */
     public function testOffsetSet()
     {
@@ -341,7 +341,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::offsetUnset()
+     * @covers \Noodlehaus\AbstractConfig::offsetUnset()
      */
     public function testOffsetUnset()
     {
@@ -350,7 +350,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::current()
+     * @covers \Noodlehaus\AbstractConfig::current()
      */
     public function testCurrent()
     {
@@ -374,7 +374,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::key()
+     * @covers \Noodlehaus\AbstractConfig::key()
      */
     public function testKey()
     {
@@ -398,7 +398,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::next()
+     * @covers \Noodlehaus\AbstractConfig::next()
      */
     public function testNext()
     {
@@ -416,7 +416,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::rewind()
+     * @covers \Noodlehaus\AbstractConfig::rewind()
      */
     public function testRewind()
     {
@@ -430,7 +430,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::valid()
+     * @covers \Noodlehaus\AbstractConfig::valid()
      */
     public function testValid()
     {
@@ -457,11 +457,11 @@ class AbstractConfigTest extends TestCase
      * Tests to verify that Iterator is properly implemented by using a foreach
      * loop on the test config
      *
-     * @covers Noodlehaus\Config::current()
-     * @covers Noodlehaus\Config::next()
-     * @covers Noodlehaus\Config::key()
-     * @covers Noodlehaus\Config::valid()
-     * @covers Noodlehaus\Config::rewind()
+     * @covers \Noodlehaus\Config::current()
+     * @covers \Noodlehaus\Config::next()
+     * @covers \Noodlehaus\Config::key()
+     * @covers \Noodlehaus\Config::valid()
+     * @covers \Noodlehaus\Config::rewind()
      */
     public function testIterator()
     {
@@ -489,7 +489,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Config::get()
+     * @covers \Noodlehaus\Config::get()
      */
     public function testGetShouldNotSet()
     {
@@ -499,7 +499,7 @@ class AbstractConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\AbstractConfig::remove()
+     * @covers \Noodlehaus\AbstractConfig::remove()
      */
     public function testRemove()
     {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,6 +1,8 @@
 <?php
-namespace Noodlehaus;
 
+namespace Noodlehaus\Test;
+
+use Noodlehaus\Config;
 use Noodlehaus\Parser\Json as JsonParser;
 use Noodlehaus\Writer\Json as JsonWriter;
 use PHPUnit\Framework\TestCase;
@@ -16,9 +18,9 @@ class ConfigTest extends TestCase
     protected $config;
 
     /**
-     * @covers Noodlehaus\Config::load()
-     * @covers Noodlehaus\Config::loadFromFile()
-     * @covers Noodlehaus\Config::getParser()
+     * @covers Config::load()
+     * @covers Config::loadFromFile()
+     * @covers Config::getParser()
      */
     public function testLoadWithUnsupportedFormat()
     {
@@ -29,9 +31,9 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Config::__construct()
-     * @covers Noodlehaus\Config::loadFromFile()
-     * @covers Noodlehaus\Config::getParser()
+     * @covers Config::__construct()
+     * @covers Config::loadFromFile()
+     * @covers Config::getParser()
      */
     public function testConstructWithUnsupportedFormat()
     {
@@ -41,11 +43,11 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Config::__construct()
-     * @covers Noodlehaus\Config::loadFromFile()
-     * @covers Noodlehaus\Config::getParser()
-     * @covers Noodlehaus\Config::getPathFromArray()
-     * @covers Noodlehaus\Config::getValidPath()
+     * @covers Config::__construct()
+     * @covers Config::loadFromFile()
+     * @covers Config::getParser()
+     * @covers Config::getPathFromArray()
+     * @covers Config::getValidPath()
      */
     public function testConstructWithInvalidPath()
     {
@@ -55,11 +57,11 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Config::__construct()
-     * @covers Noodlehaus\Config::loadFromFile()
-     * @covers Noodlehaus\Config::getParser()
-     * @covers Noodlehaus\Config::getPathFromArray()
-     * @covers Noodlehaus\Config::getValidPath()
+     * @covers Config::__construct()
+     * @covers Config::loadFromFile()
+     * @covers Config::getParser()
+     * @covers Config::getPathFromArray()
+     * @covers Config::getValidPath()
      */
     public function testConstructWithEmptyDirectory()
     {
@@ -68,11 +70,11 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Config::__construct()
-     * @covers Noodlehaus\Config::loadFromFile()
-     * @covers Noodlehaus\Config::getParser()
-     * @covers Noodlehaus\Config::getPathFromArray()
-     * @covers Noodlehaus\Config::getValidPath()
+     * @covers Config::__construct()
+     * @covers Config::loadFromFile()
+     * @covers Config::getParser()
+     * @covers Config::getPathFromArray()
+     * @covers Config::getValidPath()
      */
     public function testConstructWithArray()
     {
@@ -86,11 +88,11 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Config::__construct()
-     * @covers Noodlehaus\Config::loadFromFile()
-     * @covers Noodlehaus\Config::getParser()
-     * @covers Noodlehaus\Config::getPathFromArray()
-     * @covers Noodlehaus\Config::getValidPath()
+     * @covers Config::__construct()
+     * @covers Config::loadFromFile()
+     * @covers Config::getParser()
+     * @covers Config::getPathFromArray()
+     * @covers Config::getValidPath()
      */
     public function testConstructWithArrayWithNonexistentFile()
     {
@@ -105,11 +107,11 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Config::__construct()
-     * @covers Noodlehaus\Config::loadFromFile()
-     * @covers Noodlehaus\Config::getParser()
-     * @covers Noodlehaus\Config::getPathFromArray()
-     * @covers Noodlehaus\Config::getValidPath()
+     * @covers Config::__construct()
+     * @covers Config::loadFromFile()
+     * @covers Config::getParser()
+     * @covers Config::getPathFromArray()
+     * @covers Config::getValidPath()
      */
     public function testConstructWithArrayWithOptionalFile()
     {
@@ -123,11 +125,11 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Config::__construct()
-     * @covers Noodlehaus\Config::loadFromFile()
-     * @covers Noodlehaus\Config::getParser()
-     * @covers Noodlehaus\Config::getPathFromArray()
-     * @covers Noodlehaus\Config::getValidPath()
+     * @covers Config::__construct()
+     * @covers Config::loadFromFile()
+     * @covers Config::getParser()
+     * @covers Config::getPathFromArray()
+     * @covers Config::getValidPath()
      */
     public function testConstructWithArrayWithOptionalNonexistentFile()
     {
@@ -141,11 +143,11 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Config::__construct()
-     * @covers Noodlehaus\Config::loadFromFile()
-     * @covers Noodlehaus\Config::getParser()
-     * @covers Noodlehaus\Config::getPathFromArray()
-     * @covers Noodlehaus\Config::getValidPath()
+     * @covers Config::__construct()
+     * @covers Config::loadFromFile()
+     * @covers Config::getParser()
+     * @covers Config::getPathFromArray()
+     * @covers Config::getValidPath()
      */
     public function testConstructWithDirectory()
     {
@@ -158,11 +160,11 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Config::__construct()
-     * @covers Noodlehaus\Config::loadFromFile()
-     * @covers Noodlehaus\Config::getParser()
-     * @covers Noodlehaus\Config::getPathFromArray()
-     * @covers Noodlehaus\Config::getValidPath()
+     * @covers Config::__construct()
+     * @covers Config::loadFromFile()
+     * @covers Config::getParser()
+     * @covers Config::getPathFromArray()
+     * @covers Config::getValidPath()
      */
     public function testConstructWithYml()
     {
@@ -175,11 +177,11 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Config::__construct()
-     * @covers Noodlehaus\Config::loadFromFile()
-     * @covers Noodlehaus\Config::getParser()
-     * @covers Noodlehaus\Config::getPathFromArray()
-     * @covers Noodlehaus\Config::getValidPath()
+     * @covers Config::__construct()
+     * @covers Config::loadFromFile()
+     * @covers Config::getParser()
+     * @covers Config::getPathFromArray()
+     * @covers Config::getValidPath()
      */
     public function testConstructWithYmlDist()
     {
@@ -192,11 +194,11 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Config::__construct()
-     * @covers Noodlehaus\Config::loadFromFile()
-     * @covers Noodlehaus\Config::getParser()
-     * @covers Noodlehaus\Config::getPathFromArray()
-     * @covers Noodlehaus\Config::getValidPath()
+     * @covers Config::__construct()
+     * @covers Config::loadFromFile()
+     * @covers Config::getParser()
+     * @covers Config::getPathFromArray()
+     * @covers Config::getValidPath()
      */
     public function testConstructWithEmptyYml()
     {
@@ -209,10 +211,10 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Config::__construct()
-     * @covers Noodlehaus\Config::loadFromFile()
-     * @covers Noodlehaus\Config::getPathFromArray()
-     * @covers Noodlehaus\Config::getValidPath()
+     * @covers Config::__construct()
+     * @covers Config::loadFromFile()
+     * @covers Config::getPathFromArray()
+     * @covers Config::getValidPath()
      */
     public function testConstructWithFileParser()
     {
@@ -225,13 +227,13 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Config::__construct()
-     * @covers Noodlehaus\Config::loadFromString()
+     * @covers Config::__construct()
+     * @covers Config::loadFromString()
      */
     public function testConstructWithStringParser()
     {
         $settings = file_get_contents(__DIR__ . '/mocks/pass/config.php');
-        $config = new Config($settings, new Parser\Php, true);
+        $config = new Config($settings, new \Noodlehaus\Parser\Php, true);
 
         $expected = 'localhost';
         $actual   = $config->get('host');
@@ -240,8 +242,8 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @covers       Noodlehaus\Config::__construct()
-     * @covers       Noodlehaus\Config::get()
+     * @covers Config::__construct()
+     * @covers Config::get()
      * @dataProvider specialConfigProvider()
      */
     public function testGetReturnsArrayMergedArray($config)
@@ -250,8 +252,8 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Config::toFile()
-     * @covers Noodlehaus\Config::getWriter()
+     * @covers Config::toFile()
+     * @covers Config::getWriter()
      */
     public function testWritesToFile()
     {
@@ -264,7 +266,7 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Config::toString()
+     * @covers Config::toString()
      */
     public function testWritesToString()
     {

--- a/tests/Parser/IniTest.php
+++ b/tests/Parser/IniTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Noodlehaus\Parser\Test;
+namespace Noodlehaus\Test\Parser;
 
 use Noodlehaus\Parser\Ini;
 use PHPUnit\Framework\TestCase;
@@ -25,7 +25,7 @@ class IniTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Parser\Ini::getSupportedExtensions()
+     * @covers \Noodlehaus\Parser\Ini::getSupportedExtensions()
      */
     public function testGetSupportedExtensions()
     {
@@ -35,8 +35,8 @@ class IniTest extends TestCase
     }
 
     /**
-     * @covers                   Noodlehaus\Parser\Ini::parseFile()
-     * @covers                   Noodlehaus\Parser\Ini::parse()
+     * @covers \Noodlehaus\Parser\Ini::parseFile()
+     * @covers \Noodlehaus\Parser\Ini::parse()
      * Tests the case where an INI string contains no parsable data at all, resulting in parse_ini_string
      * returning NULL, but not setting an error retrievable by error_get_last()
      */
@@ -48,8 +48,8 @@ class IniTest extends TestCase
     }
 
     /**
-     * @covers                   Noodlehaus\Parser\Ini::parseString()
-     * @covers                   Noodlehaus\Parser\Ini::parse()
+     * @covers \Noodlehaus\Parser\Ini::parseString()
+     * @covers \Noodlehaus\Parser\Ini::parse()
      */
     public function testLoadInvalidIni()
     {
@@ -66,9 +66,9 @@ class IniTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Parser\Ini::parseFile()
-     * @covers Noodlehaus\Parser\Ini::parseString()
-     * @covers Noodlehaus\Parser\Ini::parse()
+     * @covers \Noodlehaus\Parser\Ini::parseFile()
+     * @covers \Noodlehaus\Parser\Ini::parseString()
+     * @covers \Noodlehaus\Parser\Ini::parse()
      */
     public function testLoadIni()
     {
@@ -83,10 +83,10 @@ class IniTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Parser\Ini::parseFile()
-     * @covers Noodlehaus\Parser\Ini::parseString()
-     * @covers Noodlehaus\Parser\Ini::parse()
-     * @covers Noodlehaus\Parser\Ini::expandDottedKey()
+     * @covers \Noodlehaus\Parser\Ini::parseFile()
+     * @covers \Noodlehaus\Parser\Ini::parseString()
+     * @covers \Noodlehaus\Parser\Ini::parse()
+     * @covers \Noodlehaus\Parser\Ini::expandDottedKey()
      */
     public function testLoadIniWithDottedName()
     {

--- a/tests/Parser/JsonTest.php
+++ b/tests/Parser/JsonTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Noodlehaus\Parser\Test;
+namespace Noodlehaus\Test\Parser;
 
 use Noodlehaus\Parser\Json;
 use PHPUnit\Framework\TestCase;
@@ -25,7 +25,7 @@ class JsonTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Parser\Json::getSupportedExtensions()
+     * @covers \Noodlehaus\Parser\Json::getSupportedExtensions()
      */
     public function testGetSupportedExtensions()
     {
@@ -35,8 +35,8 @@ class JsonTest extends TestCase
     }
 
     /**
-     * @covers                   Noodlehaus\Parser\Json::parseFile()
-     * @covers                   Noodlehaus\Parser\Json::parse()
+     * @covers \Noodlehaus\Parser\Json::parseFile()
+     * @covers \Noodlehaus\Parser\Json::parse()
      */
     public function testLoadInvalidJson()
     {
@@ -46,9 +46,9 @@ class JsonTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Parser\Json::parseFile()
-     * @covers Noodlehaus\Parser\Json::parseString()
-     * @covers Noodlehaus\Parser\Json::parse()
+     * @covers \Noodlehaus\Parser\Json::parseFile()
+     * @covers \Noodlehaus\Parser\Json::parseString()
+     * @covers \Noodlehaus\Parser\Json::parse()
      */
     public function testLoadJson()
     {

--- a/tests/Parser/PhpTest.php
+++ b/tests/Parser/PhpTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Noodlehaus\Parser\Test;
+namespace Noodlehaus\Test\Parser;
 
 use Noodlehaus\Parser\Php;
 use PHPUnit\Framework\TestCase;
@@ -25,7 +25,7 @@ class PhpTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Parser\Php::getSupportedExtensions()
+     * @covers \Noodlehaus\Parser\Php::getSupportedExtensions()
      */
     public function testGetSupportedExtensions()
     {
@@ -35,8 +35,8 @@ class PhpTest extends TestCase
     }
 
     /**
-     * @covers                   Noodlehaus\Parser\Php::parseFile()
-     * @covers                   Noodlehaus\Parser\Php::parse()
+     * @covers \Noodlehaus\Parser\Php::parseFile()
+     * @covers \Noodlehaus\Parser\Php::parse()
      */
     public function testLoadInvalidPhp()
     {
@@ -46,7 +46,7 @@ class PhpTest extends TestCase
     }
 
     /**
-     * @covers                   Noodlehaus\Parser\Php::parseFile()
+     * @covers \Noodlehaus\Parser\Php::parseFile()
      */
     public function testLoadExceptionalPhpFile()
     {
@@ -56,8 +56,8 @@ class PhpTest extends TestCase
     }
 
     /**
-     * @covers                   Noodlehaus\Parser\Php::parseString()
-     * @covers                   Noodlehaus\Parser\Php::isolate()
+     * @covers \Noodlehaus\Parser\Php::parseString()
+     * @covers \Noodlehaus\Parser\Php::isolate()
      */
     public function testLoadExceptionalPhpString()
     {
@@ -67,10 +67,10 @@ class PhpTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Parser\Php::parseFile()
-     * @covers Noodlehaus\Parser\Php::parseString()
-     * @covers Noodlehaus\Parser\Php::isolate()
-     * @covers Noodlehaus\Parser\Php::parse()
+     * @covers \Noodlehaus\Parser\Php::parseFile()
+     * @covers \Noodlehaus\Parser\Php::parseString()
+     * @covers \Noodlehaus\Parser\Php::isolate()
+     * @covers \Noodlehaus\Parser\Php::parse()
      */
     public function testLoadPhpArray()
     {
@@ -85,10 +85,10 @@ class PhpTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Parser\Php::parseFile()
-     * @covers Noodlehaus\Parser\Php::parseString()
-     * @covers Noodlehaus\Parser\Php::isolate()
-     * @covers Noodlehaus\Parser\Php::parse()
+     * @covers \Noodlehaus\Parser\Php::parseFile()
+     * @covers \Noodlehaus\Parser\Php::parseString()
+     * @covers \Noodlehaus\Parser\Php::isolate()
+     * @covers \Noodlehaus\Parser\Php::parse()
      */
     public function testLoadPhpCallable()
     {
@@ -103,10 +103,10 @@ class PhpTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Parser\Php::parseFile()
-     * @covers Noodlehaus\Parser\Php::parseString()
-     * @covers Noodlehaus\Parser\Php::isolate()
-     * @covers Noodlehaus\Parser\Php::parse()
+     * @covers \Noodlehaus\Parser\Php::parseFile()
+     * @covers \Noodlehaus\Parser\Php::parseString()
+     * @covers \Noodlehaus\Parser\Php::isolate()
+     * @covers \Noodlehaus\Parser\Php::parse()
      */
     public function testLoadPhpVariable()
     {

--- a/tests/Parser/PropertiesTest.php
+++ b/tests/Parser/PropertiesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Noodlehaus\Parser\Test;
+namespace Noodlehaus\Test\Parser;
 
 use Noodlehaus\Parser\Properties;
 use PHPUnit\Framework\TestCase;
@@ -22,7 +22,7 @@ class PropertiesTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Parser\Properties::getSupportedExtensions()
+     * @covers \Noodlehaus\Parser\Properties::getSupportedExtensions()
      */
     public function testGetSupportedExtensions()
     {
@@ -32,9 +32,9 @@ class PropertiesTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Parser\Properties::parseFile()
-     * @covers Noodlehaus\Parser\Properties::parseString()
-     * @covers Noodlehaus\Parser\Properties::parse()
+     * @covers \Noodlehaus\Parser\Properties::parseFile()
+     * @covers \Noodlehaus\Parser\Properties::parseString()
+     * @covers \Noodlehaus\Parser\Properties::parse()
      */
     public function testLoadProperties()
     {
@@ -50,8 +50,8 @@ class PropertiesTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Parser\Ini::parseFile()
-     * @covers Noodlehaus\Parser\Ini::parse()
+     * @covers \Noodlehaus\Parser\Ini::parseFile()
+     * @covers \Noodlehaus\Parser\Ini::parse()
      */
     public function testLoadInvalidIniGBH()
     {

--- a/tests/Parser/SerializeTest.php
+++ b/tests/Parser/SerializeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Noodlehaus\Parser\Test;
+namespace Noodlehaus\Test\Parser;
 
 use Noodlehaus\Parser\Serialize;
 use PHPUnit\Framework\TestCase;
@@ -25,7 +25,7 @@ class SerializeTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Parser\Serialize::getSupportedExtensions()
+     * @covers \Noodlehaus\Parser\Serialize::getSupportedExtensions()
      */
     public function testGetSupportedExtensions()
     {
@@ -35,8 +35,8 @@ class SerializeTest extends TestCase
     }
 
     /**
-     * @covers                   Noodlehaus\Parser\Serialize::parseFile()
-     * @covers                   Noodlehaus\Parser\Serialize::parse()
+     * @covers \Noodlehaus\Parser\Serialize::parseFile()
+     * @covers \Noodlehaus\Parser\Serialize::parse()
      */
     public function testLoadInvalidSerialize()
     {
@@ -46,9 +46,9 @@ class SerializeTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Parser\Serialize::parseFile()
-     * @covers Noodlehaus\Parser\Serialize::parseString()
-     * @covers Noodlehaus\Parser\Serialize::parse()
+     * @covers \Noodlehaus\Parser\Serialize::parseFile()
+     * @covers \Noodlehaus\Parser\Serialize::parseString()
+     * @covers \Noodlehaus\Parser\Serialize::parse()
      */
     public function testLoadSerialize()
     {

--- a/tests/Parser/XmlTest.php
+++ b/tests/Parser/XmlTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Noodlehaus\Parser\Test;
+namespace Noodlehaus\Test\Parser;
 
 use Noodlehaus\Parser\Xml;
 use PHPUnit\Framework\TestCase;
@@ -25,7 +25,7 @@ class XmlTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Parser\Xml::getSupportedExtensions()
+     * @covers \Noodlehaus\Parser\Xml::getSupportedExtensions()
      */
     public function testGetSupportedExtensions()
     {
@@ -35,8 +35,8 @@ class XmlTest extends TestCase
     }
 
     /**
-     * @covers                   Noodlehaus\Parser\Xml::parseFile()
-     * @covers                   Noodlehaus\Parser\Xml::parse()
+     * @covers \Noodlehaus\Parser\Xml::parseFile()
+     * @covers \Noodlehaus\Parser\Xml::parse()
      */
     public function testLoadInvalidXml()
     {
@@ -46,9 +46,9 @@ class XmlTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Parser\Xml::parseFile()
-     * @covers Noodlehaus\Parser\Xml::parseString()
-     * @covers Noodlehaus\Parser\Xml::parse()
+     * @covers \Noodlehaus\Parser\Xml::parseFile()
+     * @covers \Noodlehaus\Parser\Xml::parseString()
+     * @covers \Noodlehaus\Parser\Xml::parse()
      */
     public function testLoadXml()
     {

--- a/tests/Parser/YamlTest.php
+++ b/tests/Parser/YamlTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Noodlehaus\Parser\Test;
+namespace Noodlehaus\Test\Parser;
 
 use Noodlehaus\Parser\Yaml;
 use PHPUnit\Framework\TestCase;
@@ -25,7 +25,7 @@ class YamlTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Parser\Yaml::getSupportedExtensions()
+     * @covers \Noodlehaus\Parser\Yaml::getSupportedExtensions()
      */
     public function testGetSupportedExtensions()
     {
@@ -35,8 +35,8 @@ class YamlTest extends TestCase
     }
 
     /**
-     * @covers                   Noodlehaus\Parser\Yaml::parseFile()
-     * @covers                   Noodlehaus\Parser\Yaml::parse()
+     * @covers \Noodlehaus\Parser\Yaml::parseFile()
+     * @covers \Noodlehaus\Parser\Yaml::parse()
      */
     public function testLoadInvalidYamlFile()
     {
@@ -46,8 +46,8 @@ class YamlTest extends TestCase
     }
 
     /**
-     * @covers                   Noodlehaus\Parser\Yaml::parseString()
-     * @covers                   Noodlehaus\Parser\Yaml::parse()
+     * @covers \Noodlehaus\Parser\Yaml::parseString()
+     * @covers \Noodlehaus\Parser\Yaml::parse()
      */
     public function testLoadInvalidYamlString()
     {
@@ -57,8 +57,8 @@ class YamlTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Parser\Yaml::parseFile()
-     * @covers Noodlehaus\Parser\Yaml::parse()
+     * @covers \Noodlehaus\Parser\Yaml::parseFile()
+     * @covers \Noodlehaus\Parser\Yaml::parse()
      */
     public function testLoadYaml()
     {
@@ -68,7 +68,7 @@ class YamlTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Parser\Yaml::parse()
+     * @covers \Noodlehaus\Parser\Yaml::parse()
      */
     public function testLoadYml()
     {
@@ -78,7 +78,7 @@ class YamlTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Parser\Yaml::parseString()
+     * @covers \Noodlehaus\Parser\Yaml::parseString()
      */
     public function testLoadYamlString()
     {

--- a/tests/Writer/IniTest.php
+++ b/tests/Writer/IniTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Noodlehaus\Writer\Test;
+namespace Noodlehaus\Test\Writer;
 
 use Noodlehaus\Writer\Ini;
 use PHPUnit\Framework\TestCase;
@@ -52,7 +52,7 @@ class IniTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Writer\Ini::getSupportedExtensions()
+     * @covers \Noodlehaus\Writer\Ini::getSupportedExtensions()
      */
     public function testGetSupportedExtensions()
     {
@@ -62,8 +62,8 @@ class IniTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Writer\Ini::toString()
-     * @covers Noodlehaus\Writer\Ini::toINI()
+     * @covers \Noodlehaus\Writer\Ini::toString()
+     * @covers \Noodlehaus\Writer\Ini::toINI()
      */
     public function testEncodeIni()
     {
@@ -81,9 +81,9 @@ EOD;
     }
 
     /**
-     * @covers Noodlehaus\Writer\Ini::toString()
-     * @covers Noodlehaus\Writer\Ini::toFile()
-     * @covers Noodlehaus\Writer\Ini::toINI()
+     * @covers \Noodlehaus\Writer\Ini::toString()
+     * @covers \Noodlehaus\Writer\Ini::toFile()
+     * @covers \Noodlehaus\Writer\Ini::toINI()
      */
     public function testWriteIni()
     {
@@ -94,9 +94,9 @@ EOD;
     }
 
     /**
-     * @covers Noodlehaus\Writer\Ini::toString()
-     * @covers Noodlehaus\Writer\Ini::toFile()
-     * @covers Noodlehaus\Writer\Ini::toINI()
+     * @covers \Noodlehaus\Writer\Ini::toString()
+     * @covers \Noodlehaus\Writer\Ini::toFile()
+     * @covers \Noodlehaus\Writer\Ini::toINI()
      */
     public function testUnwritableFile()
     {

--- a/tests/Writer/JsonTest.php
+++ b/tests/Writer/JsonTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Noodlehaus\Writer\Test;
+namespace Noodlehaus\Test\Writer;
 
 use Noodlehaus\Writer\Json;
 use PHPUnit\Framework\TestCase;
@@ -55,7 +55,7 @@ class JsonTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Writer\Json::getSupportedExtensions()
+     * @covers \Noodlehaus\Writer\Json::getSupportedExtensions()
      */
     public function testGetSupportedExtensions()
     {
@@ -65,7 +65,7 @@ class JsonTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Writer\Json::toString()
+     * @covers \Noodlehaus\Writer\Json::toString()
      */
     public function testEncodeJson()
     {
@@ -76,8 +76,8 @@ class JsonTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Writer\Json::toString()
-     * @covers Noodlehaus\Writer\Json::toFile()
+     * @covers \Noodlehaus\Writer\Json::toString()
+     * @covers \Noodlehaus\Writer\Json::toFile()
      */
     public function testWriteJson()
     {
@@ -88,8 +88,8 @@ class JsonTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Writer\Json::toString()
-     * @covers Noodlehaus\Writer\Json::toFile()
+     * @covers \Noodlehaus\Writer\Json::toString()
+     * @covers \Noodlehaus\Writer\Json::toFile()
      */
     public function testUnwritableFile()
     {

--- a/tests/Writer/PropertiesTest.php
+++ b/tests/Writer/PropertiesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Noodlehaus\Writer\Test;
+namespace Noodlehaus\Test\Writer;
 
 use Noodlehaus\Writer\Properties;
 use PHPUnit\Framework\TestCase;
@@ -51,7 +51,7 @@ class PropertiesTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Writer\Properties::getSupportedExtensions()
+     * @covers \Noodlehaus\Writer\Properties::getSupportedExtensions()
      */
     public function testGetSupportedExtensions()
     {
@@ -61,8 +61,8 @@ class PropertiesTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Writer\Properties::toString()
-     * @covers Noodlehaus\Writer\Properties::toProperties()
+     * @covers \Noodlehaus\Writer\Properties::toString()
+     * @covers \Noodlehaus\Writer\Properties::toProperties()
      */
     public function testEncodeProperties()
     {
@@ -82,9 +82,9 @@ EOD;
     }
 
     /**
-     * @covers Noodlehaus\Writer\Properties::toString()
-     * @covers Noodlehaus\Writer\Properties::toFile()
-     * @covers Noodlehaus\Writer\Properties::toProperties()
+     * @covers \Noodlehaus\Writer\Properties::toString()
+     * @covers \Noodlehaus\Writer\Properties::toFile()
+     * @covers \Noodlehaus\Writer\Properties::toProperties()
      */
     public function testWriteProperties()
     {
@@ -95,9 +95,9 @@ EOD;
     }
 
     /**
-     * @covers Noodlehaus\Writer\Properties::toString()
-     * @covers Noodlehaus\Writer\Properties::toFile()
-     * @covers Noodlehaus\Writer\Properties::toProperties()
+     * @covers \Noodlehaus\Writer\Properties::toString()
+     * @covers \Noodlehaus\Writer\Properties::toFile()
+     * @covers \Noodlehaus\Writer\Properties::toProperties()
      */
     public function testUnwritableFile()
     {

--- a/tests/Writer/SerializeTest.php
+++ b/tests/Writer/SerializeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Noodlehaus\Writer\Test;
+namespace Noodlehaus\Test\Writer;
 
 use Noodlehaus\Writer\Serialize;
 use PHPUnit\Framework\TestCase;
@@ -55,7 +55,7 @@ class SerializeTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Writer\Serialize::getSupportedExtensions()
+     * @covers \Noodlehaus\Writer\Serialize::getSupportedExtensions()
      */
     public function testGetSupportedExtensions()
     {
@@ -65,7 +65,7 @@ class SerializeTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Writer\Serialize::toString()
+     * @covers \Noodlehaus\Writer\Serialize::toString()
      */
     public function testSerialize()
     {
@@ -76,8 +76,8 @@ class SerializeTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Writer\Serialize::toString()
-     * @covers Noodlehaus\Writer\Serialize::toFile()
+     * @covers \Noodlehaus\Writer\Serialize::toString()
+     * @covers \Noodlehaus\Writer\Serialize::toFile()
      */
     public function testWriteSerialize()
     {
@@ -88,8 +88,8 @@ class SerializeTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Writer\Serialize::toString()
-     * @covers Noodlehaus\Writer\Serialize::toFile()
+     * @covers \Noodlehaus\Writer\Serialize::toString()
+     * @covers \Noodlehaus\Writer\Serialize::toFile()
      */
     public function testUnwritableFile()
     {

--- a/tests/Writer/XmlTest.php
+++ b/tests/Writer/XmlTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Noodlehaus\Writer\Test;
+namespace Noodlehaus\Test\Writer;
 
 use Noodlehaus\Writer\Xml;
 use PHPUnit\Framework\TestCase;
@@ -55,7 +55,7 @@ class XmlTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Writer\Xml::getSupportedExtensions()
+     * @covers \Noodlehaus\Writer\Xml::getSupportedExtensions()
      */
     public function testGetSupportedExtensions()
     {
@@ -65,8 +65,8 @@ class XmlTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Writer\Xml::toString()
-     * @covers Noodlehaus\Writer\Xml::toXML()
+     * @covers \Noodlehaus\Writer\Xml::toString()
+     * @covers \Noodlehaus\Writer\Xml::toXML()
      */
     public function testEncodeXml()
     {
@@ -80,9 +80,9 @@ EOD;
     }
 
     /**
-     * @covers Noodlehaus\Writer\Xml::toFile()
-     * @covers Noodlehaus\Writer\Xml::toString()
-     * @covers Noodlehaus\Writer\Xml::toXML()
+     * @covers \Noodlehaus\Writer\Xml::toFile()
+     * @covers \Noodlehaus\Writer\Xml::toString()
+     * @covers \Noodlehaus\Writer\Xml::toXML()
      */
     public function testWriteXml()
     {
@@ -93,8 +93,8 @@ EOD;
     }
 
     /**
-     * @covers Noodlehaus\Writer\Xml::toFile()
-     * @covers Noodlehaus\Writer\Xml::toXML()
+     * @covers \Noodlehaus\Writer\Xml::toFile()
+     * @covers \Noodlehaus\Writer\Xml::toXML()
      */
     public function testUnwritableFile()
     {

--- a/tests/Writer/YamlTest.php
+++ b/tests/Writer/YamlTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Noodlehaus\Writer\Test;
+namespace Noodlehaus\Test\Writer;
 
 use Noodlehaus\Writer\Yaml;
 use PHPUnit\Framework\TestCase;
@@ -55,7 +55,7 @@ class YamlTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Writer\Yaml::getSupportedExtensions()
+     * @covers \Noodlehaus\Writer\Yaml::getSupportedExtensions()
      */
     public function testGetSupportedExtensions()
     {
@@ -65,7 +65,7 @@ class YamlTest extends TestCase
     }
 
     /**
-     * @covers Noodlehaus\Writer\Yaml::toString()
+     * @covers \Noodlehaus\Writer\Yaml::toString()
      */
     public function testEncodeYaml()
     {
@@ -86,8 +86,8 @@ EOD;
     }
 
     /**
-     * @covers Noodlehaus\Writer\Yaml::toString()
-     * @covers Noodlehaus\Writer\Yaml::toFile()
+     * @covers \Noodlehaus\Writer\Yaml::toString()
+     * @covers \Noodlehaus\Writer\Yaml::toFile()
      */
     public function testWriteYaml()
     {
@@ -97,8 +97,8 @@ EOD;
     }
 
     /**
-     * @covers Noodlehaus\Writer\Yaml::toString()
-     * @covers Noodlehaus\Writer\Yaml::toFile()
+     * @covers \Noodlehaus\Writer\Yaml::toString()
+     * @covers \Noodlehaus\Writer\Yaml::toFile()
      */
     public function testUnwritableFile()
     {


### PR DESCRIPTION
This PR;
- allows tests to run on PHP 8.2,
- bumps `actions/checkout` to the latest version,
- removes unused imports,
- fixes namespaces in tests since they don't match PSR-4 project structure as defined in [`composer.json`](https://github.com/hassankhan/config/blob/develop/composer.json#L34).