### PR TITLE
Use PHP native type declarations 🐘

### DIFF
--- a/src/AbstractConfig.php
+++ b/src/AbstractConfig.php
@@ -18,22 +18,16 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
 {
     /**
      * Stores the configuration data
-     *
-     * @var array|null
      */
-    protected $data = null;
+    protected ?array $data = null;
 
     /**
      * Caches the configuration data
-     *
-     * @var array
      */
-    protected $cache = [];
+    protected array $cache = [];
 
     /**
      * Constructor method and sets default options, if any
-     *
-     * @param array $data
      */
     public function __construct(array $data)
     {
@@ -44,11 +38,9 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
      * Override this method in your own subclass to provide an array of default
      * options and values
      *
-     * @return array
-     *
      * @codeCoverageIgnore
      */
-    protected function getDefaults()
+    protected function getDefaults(): array
     {
         return [];
     }
@@ -60,7 +52,7 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
     /**
      * {@inheritDoc}
      */
-    public function get($key, $default = null)
+    public function get(string $key, $default = null)
     {
         if ($this->has($key)) {
             return $this->cache[$key];
@@ -72,7 +64,7 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
     /**
      * {@inheritDoc}
      */
-    public function set($key, $value)
+    public function set(string $key, $value): void
     {
         $segs = explode('.', $key);
         $root = &$this->data;
@@ -111,7 +103,7 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
     /**
      * {@inheritDoc}
      */
-    public function has($key)
+    public function has(string $key): bool
     {
         // Check if already cached
         if (isset($this->cache[$key])) {
@@ -139,11 +131,8 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
 
     /**
      * Merge config from another instance
-     *
-     * @param ConfigInterface $config
-     * @return ConfigInterface
      */
-    public function merge(ConfigInterface $config)
+    public function merge(ConfigInterface $config): self
     {
         $this->data = array_replace_recursive($this->data, $config->all());
         $this->cache = [];
@@ -153,7 +142,7 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
     /**
      * {@inheritDoc}
      */
-    public function all()
+    public function all(): array
     {
         return $this->data;
     }
@@ -183,7 +172,7 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
      * @return bool
      */
     #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->has($offset);
     }
@@ -197,7 +186,7 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
      * @return void
      */
     #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->set($offset, $value);
     }
@@ -210,7 +199,7 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
      * @return void
      */
     #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->set($offset, null);
     }
@@ -280,19 +269,15 @@ abstract class AbstractConfig implements ArrayAccess, ConfigInterface, Iterator
      * @return bool True if the current index is valid; false otherwise
      */
     #[\ReturnTypeWillChange]
-    public function valid()
+    public function valid(): bool
     {
         return (is_array($this->data) ? key($this->data) !== null : false);
     }
 
     /**
      * Remove a value using the offset as a key
-     *
-     * @param  string $key
-     *
-     * @return void
      */
-    public function remove($key)
+    public function remove(string $key): void
     {
         $this->offsetUnset($key);
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -22,10 +22,8 @@ class Config extends AbstractConfig
 {
     /**
      * All formats supported by Config.
-     *
-     * @var array
      */
-    protected $supportedParsers = [
+    protected array $supportedParsers = [
         'Noodlehaus\Parser\Php',
         'Noodlehaus\Parser\Ini',
         'Noodlehaus\Parser\Json',
@@ -37,10 +35,8 @@ class Config extends AbstractConfig
 
     /**
      * All formats supported by Config.
-     *
-     * @var array
      */
-    protected $supportedWriters = [
+    protected array $supportedWriters = [
         'Noodlehaus\Writer\Ini',
         'Noodlehaus\Writer\Json',
         'Noodlehaus\Writer\Xml',
@@ -52,13 +48,13 @@ class Config extends AbstractConfig
     /**
      * Static method for loading a Config instance.
      *
-     * @param  string|array    $values Filenames or string with configuration
-     * @param  ParserInterface $parser Configuration parser
-     * @param  bool            $string Enable loading from string
+     * @param  string|array          $values  Filenames or string with configuration
+     * @param  ParserInterface|null  $parser  Configuration parser
+     * @param  bool                  $string  Enable loading from string
      *
      * @return Config
      */
-    public static function load($values, $parser = null, $string = false)
+    public static function load($values, ?ParserInterface $parser = null, bool $string = false): self
     {
         return new static($values, $parser, $string);
     }
@@ -66,11 +62,11 @@ class Config extends AbstractConfig
     /**
      * Loads a Config instance.
      *
-     * @param  string|array    $values Filenames or string with configuration
-     * @param  ParserInterface $parser Configuration parser
-     * @param  bool            $string Enable loading from string
+     * @param  string|array          $values  Filenames or string with configuration
+     * @param  ParserInterface|null  $parser  Configuration parser
+     * @param  bool                  $string  Enable loading from string
      */
-    public function __construct($values, ParserInterface $parser = null, $string = false)
+    public function __construct($values, ?ParserInterface $parser = null, bool $string = false)
     {
         if ($string === true) {
             $this->loadFromString($values, $parser);
@@ -84,12 +80,12 @@ class Config extends AbstractConfig
     /**
      * Loads configuration from file.
      *
-     * @param  string|array     $path   Filenames or directories with configuration
-     * @param  ParserInterface  $parser Configuration parser
+     * @param  string|array          $path    Filenames or directories with configuration
+     * @param  ParserInterface|null  $parser  Configuration parser
      *
      * @throws EmptyDirectoryException If `$path` is an empty directory
      */
-    protected function loadFromFile($path, ParserInterface $parser = null)
+    protected function loadFromFile($path, ?ParserInterface $parser = null): void
     {
         $paths      = $this->getValidPath($path);
         $this->data = [];
@@ -124,12 +120,9 @@ class Config extends AbstractConfig
     /**
      * Writes configuration to file.
      *
-     * @param  string           $filename   Filename to save configuration to
-     * @param  WriterInterface  $writer Configuration writer
-     *
      * @throws WriteException if the data could not be written to the file
      */
-    public function toFile($filename, WriterInterface $writer = null)
+    public function toFile(string $filename, ?WriterInterface $writer = null): void
     {
         if ($writer === null) {
             // Get file information
@@ -158,11 +151,8 @@ class Config extends AbstractConfig
 
     /**
      * Loads configuration from string.
-     *
-     * @param string          $configuration String with configuration
-     * @param ParserInterface $parser        Configuration parser
      */
-    protected function loadFromString($configuration, ParserInterface $parser)
+    protected function loadFromString(string $configuration, ParserInterface $parser): void
     {
         $this->data = [];
 
@@ -172,11 +162,8 @@ class Config extends AbstractConfig
 
     /**
      * Writes configuration to string.
-     *
-     * @param  WriterInterface  $writer Configuration writer
-     * @param boolean           $pretty Encode pretty
      */
-    public function toString(WriterInterface $writer, $pretty = true)
+    public function toString(WriterInterface $writer, bool $pretty = true): string
     {
         return $writer->toString($this->all(), $pretty);
     }
@@ -184,13 +171,9 @@ class Config extends AbstractConfig
     /**
      * Gets a parser for a given file extension.
      *
-     * @param  string $extension
-     *
-     * @return Noodlehaus\Parser\ParserInterface
-     *
      * @throws UnsupportedFormatException If `$extension` is an unsupported file format
      */
-    protected function getParser($extension)
+    protected function getParser(string $extension): ParserInterface
     {
         foreach ($this->supportedParsers as $parser) {
             if (in_array($extension, $parser::getSupportedExtensions())) {
@@ -205,13 +188,9 @@ class Config extends AbstractConfig
     /**
      * Gets a writer for a given file extension.
      *
-     * @param  string $extension
-     *
-     * @return Noodlehaus\Writer\WriterInterface
-     *
      * @throws UnsupportedFormatException If `$extension` is an unsupported file format
      */
-    protected function getWriter($extension)
+    protected function getWriter(string $extension): WriterInterface
     {
         foreach ($this->supportedWriters as $writer) {
             if (in_array($extension, $writer::getSupportedExtensions())) {
@@ -226,13 +205,9 @@ class Config extends AbstractConfig
     /**
      * Gets an array of paths
      *
-     * @param  array $path
-     *
-     * @return array
-     *
      * @throws FileNotFoundException   If a file is not found at `$path`
      */
-    protected function getPathFromArray($path)
+    protected function getPathFromArray(array $path): array
     {
         $paths = [];
 
@@ -270,10 +245,9 @@ class Config extends AbstractConfig
      * @return array
      *
      * @throws EmptyDirectoryException If `$path` is an empty directory
-     *
      * @throws FileNotFoundException   If a file is not found at `$path`
      */
-    protected function getValidPath($path)
+    protected function getValidPath($path): array
     {
         // If `$path` is array
         if (is_array($path)) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -48,11 +48,7 @@ class Config extends AbstractConfig
     /**
      * Static method for loading a Config instance.
      *
-     * @param  string|array          $values  Filenames or string with configuration
-     * @param  ParserInterface|null  $parser  Configuration parser
-     * @param  bool                  $string  Enable loading from string
-     *
-     * @return Config
+     * @param  string|array  $values  Filenames or string with configuration
      */
     public static function load($values, ?ParserInterface $parser = null, bool $string = false): self
     {
@@ -62,9 +58,7 @@ class Config extends AbstractConfig
     /**
      * Loads a Config instance.
      *
-     * @param  string|array          $values  Filenames or string with configuration
-     * @param  ParserInterface|null  $parser  Configuration parser
-     * @param  bool                  $string  Enable loading from string
+     * @param  string|array  $values  Filenames or string with configuration
      */
     public function __construct($values, ?ParserInterface $parser = null, bool $string = false)
     {
@@ -81,7 +75,6 @@ class Config extends AbstractConfig
      * Loads configuration from file.
      *
      * @param  string|array          $path    Filenames or directories with configuration
-     * @param  ParserInterface|null  $parser  Configuration parser
      *
      * @throws EmptyDirectoryException If `$path` is an empty directory
      */
@@ -241,8 +234,6 @@ class Config extends AbstractConfig
      * Checks `$path` to see if it is either an array, a directory, or a file.
      *
      * @param  string|array $path
-     *
-     * @return array
      *
      * @throws EmptyDirectoryException If `$path` is an empty directory
      * @throws FileNotFoundException   If a file is not found at `$path`

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -23,7 +23,7 @@ interface ConfigInterface
      *
      * @return mixed
      */
-    public function get($key, $default = null);
+    public function get(string $key, $default = null);
 
     /**
      * Function for setting configuration values, using
@@ -34,22 +34,16 @@ interface ConfigInterface
      *
      * @return void
      */
-    public function set($key, $value);
+    public function set(string $key, $value): void;
 
     /**
      * Function for checking if configuration values exist, using
      * either simple or nested keys.
-     *
-     * @param  string $key
-     *
-     * @return boolean
      */
-    public function has($key);
+    public function has(string $key): bool;
     
     /**
      * Get all of the configuration items
-     *
-     * @return array
      */
-    public function all();
+    public function all(): array;
 }

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -18,7 +18,6 @@ interface ConfigInterface
      * Nested keys are similar to JSON paths that use the dot
      * dot notation.
      *
-     * @param  string $key
      * @param  mixed  $default
      *
      * @return mixed
@@ -29,7 +28,6 @@ interface ConfigInterface
      * Function for setting configuration values, using
      * either simple or nested keys.
      *
-     * @param  string $key
      * @param  mixed  $value
      *
      * @return void

--- a/src/Exception/ParseException.php
+++ b/src/Exception/ParseException.php
@@ -8,12 +8,12 @@ class ParseException extends ErrorException
 {
     public function __construct(array $error)
     {
-        $message   = $error['message'] ?: 'There was an error parsing the file';
-        $code      = isset($error['code']) ? $error['code'] : 0;
-        $severity  = isset($error['type']) ? $error['type'] : 1;
-        $filename  = isset($error['file']) ? $error['file'] : __FILE__;
-        $lineno    = isset($error['line']) ? $error['line'] : __LINE__;
-        $exception = isset($error['exception']) ? $error['exception'] : null;
+        $message   = $error['message'] ?? 'There was an error parsing the file';
+        $code      = $error['code'] ?? 0;
+        $severity  = $error['type'] ?? 1;
+        $filename  = $error['file'] ?? __FILE__;
+        $lineno    = $error['line'] ?? __LINE__;
+        $exception = $error['exception'] ?? null;
 
         parent::__construct($message, $code, $severity, $filename, $lineno, $exception);
     }

--- a/src/Exception/WriteException.php
+++ b/src/Exception/WriteException.php
@@ -8,11 +8,11 @@ class WriteException extends ErrorException
 {
     public function __construct(array $error)
     {
-        $message = isset($error['message']) ? $error['message'] : 'There was an error writing the file';
-        $code = isset($error['code']) ? $error['code'] : 0;
-        $severity = isset($error['type']) ? $error['type'] : 1;
-        $filename = isset($error['file']) ? $error['file'] : __FILE__;
-        $exception = isset($error['exception']) ? $error['exception'] : null;
+        $message = $error['message'] ?? 'There was an error writing the file';
+        $code = $error['code'] ?? 0;
+        $severity = $error['type'] ?? 1;
+        $filename = $error['file'] ?? __FILE__;
+        $exception = $error['exception'] ?? null;
 
         parent::__construct($message, $code, $severity, $filename, $exception);
     }

--- a/src/Parser/AbstractParser.php
+++ b/src/Parser/AbstractParser.php
@@ -17,20 +17,15 @@ abstract class AbstractParser implements ParserInterface
 
     /**
      * String with configuration
-     *
-     * @var string
      */
-    protected $config;
+    protected string $config;
 
     /**
      * Sets the string with configuration
      *
-     * @param string $config
-     * @param string $filename
-     *
      * @codeCoverageIgnore
      */
-    public function __construct($config, $filename = null)
+    public function __construct(string $config, ?string $filename = null)
     {
         $this->config = $config;
     }

--- a/src/Parser/AbstractParser.php
+++ b/src/Parser/AbstractParser.php
@@ -14,7 +14,6 @@ namespace Noodlehaus\Parser;
  */
 abstract class AbstractParser implements ParserInterface
 {
-
     /**
      * String with configuration
      */

--- a/src/Parser/Ini.php
+++ b/src/Parser/Ini.php
@@ -22,7 +22,7 @@ class Ini implements ParserInterface
      *
      * @throws ParseException If there is an error parsing the INI file
      */
-    public function parseFile($filename)
+    public function parseFile(string $filename): array
     {
         $data = @parse_ini_file($filename, true);
         return $this->parse($data, $filename);
@@ -34,7 +34,7 @@ class Ini implements ParserInterface
      *
      * @throws ParseException If there is an error parsing the INI string
      */
-    public function parseString($config)
+    public function parseString(string $config): array
     {
         $data = @parse_ini_string($config, true);
         return $this->parse($data);
@@ -43,12 +43,13 @@ class Ini implements ParserInterface
     /**
      * Completes parsing of INI data
      *
-     * @param  array   $data
-     * @param  string $filename
+     * @param  array|false|null $data
+     * @param  string|null      $filename
      *
+     * @return array
      * @throws ParseException If there is an error parsing the INI data
      */
-    protected function parse($data = null, $filename = null)
+    protected function parse($data, ?string $filename = null): array
     {
         if (!$data) {
             $error = error_get_last();
@@ -74,12 +75,8 @@ class Ini implements ParserInterface
 
     /**
      * Expand array with dotted keys to multidimensional array
-     *
-     * @param array $data
-     *
-     * @return array
      */
-    protected function expandDottedKey($data)
+    protected function expandDottedKey(array $data): array
     {
         foreach ($data as $key => $value) {
             if (($found = strpos($key, '.')) !== false) {
@@ -101,7 +98,7 @@ class Ini implements ParserInterface
     /**
      * {@inheritDoc}
      */
-    public static function getSupportedExtensions()
+    public static function getSupportedExtensions(): array
     {
         return ['ini'];
     }

--- a/src/Parser/Ini.php
+++ b/src/Parser/Ini.php
@@ -92,6 +92,7 @@ class Ini implements ParserInterface
                 unset($data[$key]);
             }
         }
+
         return $data;
     }
 

--- a/src/Parser/Json.php
+++ b/src/Parser/Json.php
@@ -22,7 +22,7 @@ class Json implements ParserInterface
      *
      * @throws ParseException If there is an error parsing the JSON file
      */
-    public function parseFile($filename)
+    public function parseFile(string $filename): array
     {
         $data = json_decode(file_get_contents($filename), true);
 
@@ -35,7 +35,7 @@ class Json implements ParserInterface
      *
      * @throws ParseException If there is an error parsing the JSON string
      */
-    public function parseString($config)
+    public function parseString(string $config): array
     {
         $data = json_decode($config, true);
 
@@ -45,13 +45,9 @@ class Json implements ParserInterface
     /**
      * Completes parsing of JSON data
      *
-     * @param  array  $data
-     * @param  string $filename
-     * @return array|null
-     *
      * @throws ParseException If there is an error parsing the JSON data
      */
-    protected function parse($data = null, $filename = null)
+    protected function parse(?array $data = null, ?string $filename = null): ?array
     {
         if (json_last_error() !== JSON_ERROR_NONE) {
             $error_message  = 'Syntax error';
@@ -74,7 +70,7 @@ class Json implements ParserInterface
     /**
      * {@inheritDoc}
      */
-    public static function getSupportedExtensions()
+    public static function getSupportedExtensions(): array
     {
         return ['json'];
     }

--- a/src/Parser/Json.php
+++ b/src/Parser/Json.php
@@ -26,7 +26,7 @@ class Json implements ParserInterface
     {
         $data = json_decode(file_get_contents($filename), true);
 
-        return (array)$this->parse($data, $filename);
+        return (array) $this->parse($data, $filename);
     }
 
     /**
@@ -39,7 +39,7 @@ class Json implements ParserInterface
     {
         $data = json_decode($config, true);
 
-        return (array)$this->parse($data);
+        return (array) $this->parse($data);
     }
 
     /**

--- a/src/Parser/ParserInterface.php
+++ b/src/Parser/ParserInterface.php
@@ -16,26 +16,16 @@ interface ParserInterface
 {
     /**
      * Parses a configuration from file `$filename` and gets its contents as an array
-     *
-     * @param  string $filename
-     *
-     * @return array
      */
-    public function parseFile($filename);
+    public function parseFile(string $filename): array;
 
     /**
      * Parses a configuration from string `$config` and gets its contents as an array
-     *
-     * @param  string $config
-     *
-     * @return array
      */
-    public function parseString($config);
+    public function parseString(string $config): array;
 
     /**
      * Returns an array of allowed file extensions for this parser
-     *
-     * @return array
      */
-    public static function getSupportedExtensions();
+    public static function getSupportedExtensions(): array;
 }

--- a/src/Parser/Php.php
+++ b/src/Parser/Php.php
@@ -40,7 +40,7 @@ class Php implements ParserInterface
         }
 
         // Complete parsing
-        return (array)$this->parse($data, $filename);
+        return $this->parse($data, $filename);
     }
 
     /**
@@ -71,7 +71,7 @@ class Php implements ParserInterface
         }
 
         // Complete parsing
-        return (array)$this->parse($data);
+        return $this->parse($data);
     }
 
     /**

--- a/src/Parser/Php.php
+++ b/src/Parser/Php.php
@@ -25,7 +25,7 @@ class Php implements ParserInterface
      * @throws ParseException             If the PHP file throws an exception
      * @throws UnsupportedFormatException If the PHP file does not return an array
      */
-    public function parseFile($filename)
+    public function parseFile(string $filename): array
     {
         // Run the fileEval the string, if it throws an exception, rethrow it
         try {
@@ -50,7 +50,7 @@ class Php implements ParserInterface
      * @throws ParseException             If the PHP string throws an exception
      * @throws UnsupportedFormatException If the PHP string does not return an array
      */
-    public function parseString($config)
+    public function parseString(string $config): array
     {
         // Handle PHP start tag
         $config = trim($config);
@@ -77,13 +77,13 @@ class Php implements ParserInterface
     /**
      * Completes parsing of PHP data
      *
-     * @param  array $data
-     * @param  string $filename
+     * @param  array|callable|null $data
+     * @param  string|null         $filename
      *
-     * @return array|null
+     * @return array
      * @throws UnsupportedFormatException
      */
-    protected function parse($data = null, $filename = null)
+    protected function parse($data = null, ?string $filename = null): array
     {
         // If we have a callable, run it and expect an array back
         if (is_callable($data)) {
@@ -103,9 +103,9 @@ class Php implements ParserInterface
      *
      * @param  string $EGsfKPdue7ahnMTy
      *
-     * @return array
+     * @return array|callable
      */
-    protected function isolate($EGsfKPdue7ahnMTy)
+    protected function isolate(string $EGsfKPdue7ahnMTy)
     {
         return eval($EGsfKPdue7ahnMTy);
     }
@@ -113,7 +113,7 @@ class Php implements ParserInterface
     /**
      * {@inheritDoc}
      */
-    public static function getSupportedExtensions()
+    public static function getSupportedExtensions(): array
     {
         return ['php'];
     }

--- a/src/Parser/Properties.php
+++ b/src/Parser/Properties.php
@@ -19,7 +19,7 @@ class Properties implements ParserInterface
      * {@inheritdoc}
      * Parses a Properties file as an array.
      */
-    public function parseFile($filename)
+    public function parseFile(string $filename): array
     {
         return $this->parse(file_get_contents($filename));
     }
@@ -28,12 +28,12 @@ class Properties implements ParserInterface
      * {@inheritdoc}
      * Parses a Properties string as an array.
      */
-    public function parseString($config)
+    public function parseString(string $config): array
     {
         return $this->parse($config);
     }
 
-    private function parse($txtProperties)
+    private function parse(string $txtProperties): array
     {
         $result = [];
 
@@ -53,7 +53,7 @@ class Properties implements ParserInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedExtensions()
+    public static function getSupportedExtensions(): array
     {
         return ['properties'];
     }

--- a/src/Parser/Serialize.php
+++ b/src/Parser/Serialize.php
@@ -11,7 +11,6 @@ use Noodlehaus\Exception\ParseException;
  */
 class Serialize implements ParserInterface
 {
-
     /**
      * {@inheritdoc}
      */
@@ -29,7 +28,6 @@ class Serialize implements ParserInterface
     {
         return (array) $this->parse($config);
     }
-
 
     /**
      * Completes parsing of JSON data

--- a/src/Parser/Serialize.php
+++ b/src/Parser/Serialize.php
@@ -37,8 +37,8 @@ class Serialize implements ParserInterface
     protected function parse(string $data, ?string $filename = null): ?array
     {
         $serializedData = @unserialize($data);
-        if($serializedData === false){
 
+        if ($serializedData === false) {
             throw new ParseException(error_get_last());
         }
 

--- a/src/Parser/Serialize.php
+++ b/src/Parser/Serialize.php
@@ -15,7 +15,7 @@ class Serialize implements ParserInterface
     /**
      * {@inheritdoc}
      */
-    public function parseFile($filename)
+    public function parseFile(string $filename): array
     {
         $data = file_get_contents($filename);
 
@@ -25,7 +25,7 @@ class Serialize implements ParserInterface
     /**
      * {@inheritdoc}
      */
-    public function parseString($config)
+    public function parseString(string $config): array
     {
         return (array) $this->parse($config);
     }
@@ -34,13 +34,9 @@ class Serialize implements ParserInterface
     /**
      * Completes parsing of JSON data
      *
-     * @param  string  $data
-     * @param  string $filename
-     * @return array|null
-     *
      * @throws ParseException If there is an error parsing the serialized data
      */
-    protected function parse($data = null, $filename = null)
+    protected function parse(string $data, ?string $filename = null): ?array
     {
         $serializedData = @unserialize($data);
         if($serializedData === false){
@@ -54,7 +50,7 @@ class Serialize implements ParserInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedExtensions()
+    public static function getSupportedExtensions(): array
     {
         return ['txt'];
     }

--- a/src/Parser/Xml.php
+++ b/src/Parser/Xml.php
@@ -22,7 +22,7 @@ class Xml implements ParserInterface
      *
      * @throws ParseException If there is an error parsing the XML file
      */
-    public function parseFile($filename)
+    public function parseFile(string $filename): array
     {
         libxml_use_internal_errors(true);
         $data = simplexml_load_file($filename, null, LIBXML_NOERROR);
@@ -36,7 +36,7 @@ class Xml implements ParserInterface
      *
      * @throws ParseException If there is an error parsing the XML string
      */
-    public function parseString($config)
+    public function parseString(string $config): array
     {
         libxml_use_internal_errors(true);
         $data = simplexml_load_string($config, null, LIBXML_NOERROR);
@@ -46,14 +46,14 @@ class Xml implements ParserInterface
     /**
      * Completes parsing of XML data
      *
-     * @param  \SimpleXMLElement|null $data
-     * @param  string $filename
+     * @param  \SimpleXMLElement|false|null $data
+     * @param  string|null $filename
      *
      * @return array|null
      *
      * @throws ParseException If there is an error parsing the XML data
      */
-    protected function parse($data = null, $filename = null)
+    protected function parse($data = null, ?string $filename = null): ?array
     {
         if ($data === false) {
             $errors      = libxml_get_errors();
@@ -76,7 +76,7 @@ class Xml implements ParserInterface
     /**
      * {@inheritDoc}
      */
-    public static function getSupportedExtensions()
+    public static function getSupportedExtensions(): array
     {
         return ['xml'];
     }

--- a/src/Parser/Xml.php
+++ b/src/Parser/Xml.php
@@ -27,7 +27,7 @@ class Xml implements ParserInterface
         libxml_use_internal_errors(true);
         $data = simplexml_load_file($filename, null, LIBXML_NOERROR);
 
-        return (array)$this->parse($data, $filename);
+        return (array) $this->parse($data, $filename);
     }
 
     /**
@@ -40,7 +40,7 @@ class Xml implements ParserInterface
     {
         libxml_use_internal_errors(true);
         $data = simplexml_load_string($config, null, LIBXML_NOERROR);
-        return (array)$this->parse($data);
+        return (array) $this->parse($data);
     }
 
     /**
@@ -68,9 +68,7 @@ class Xml implements ParserInterface
             throw new ParseException($error);
         }
 
-        $data = json_decode(json_encode($data), true);
-
-        return $data;
+        return json_decode(json_encode($data), true);
     }
 
     /**

--- a/src/Parser/Yaml.php
+++ b/src/Parser/Yaml.php
@@ -24,7 +24,7 @@ class Yaml implements ParserInterface
      *
      * @throws ParseException If there is an error parsing the YAML file
      */
-    public function parseFile($filename)
+    public function parseFile(string $filename): array
     {
         try {
             $data = YamlParser::parseFile($filename, YamlParser::PARSE_CONSTANT);
@@ -46,7 +46,7 @@ class Yaml implements ParserInterface
      *
      * @throws ParseException If If there is an error parsing the YAML string
      */
-    public function parseString($config)
+    public function parseString(string $config): array
     {
         try {
             $data = YamlParser::parse($config, YamlParser::PARSE_CONSTANT);
@@ -64,12 +64,8 @@ class Yaml implements ParserInterface
 
     /**
      * Completes parsing of YAML/YML data
-     *
-     * @param  array $data
-     *
-     * @return array|null
      */
-    protected function parse($data = null)
+    protected function parse(?array $data = null): ?array
     {
         return $data;
     }
@@ -77,7 +73,7 @@ class Yaml implements ParserInterface
     /**
      * {@inheritDoc}
      */
-    public static function getSupportedExtensions()
+    public static function getSupportedExtensions(): array
     {
         return ['yaml', 'yml'];
     }

--- a/src/Parser/Yaml.php
+++ b/src/Parser/Yaml.php
@@ -37,7 +37,7 @@ class Yaml implements ParserInterface
             );
         }
 
-        return (array)$this->parse($data);
+        return (array) $this->parse($data);
     }
 
     /**
@@ -59,7 +59,7 @@ class Yaml implements ParserInterface
             );
         }
 
-        return (array)$this->parse($data);
+        return (array) $this->parse($data);
     }
 
     /**

--- a/src/Writer/AbstractWriter.php
+++ b/src/Writer/AbstractWriter.php
@@ -20,7 +20,7 @@ abstract class AbstractWriter implements WriterInterface
     /**
      * {@inheritdoc}
      */
-    public function toFile($config, $filename)
+    public function toFile(array $config, string $filename): string
     {
         $contents = $this->toString($config);
         $success = @file_put_contents($filename, $contents);

--- a/src/Writer/Ini.php
+++ b/src/Writer/Ini.php
@@ -18,7 +18,7 @@ class Ini extends AbstractWriter
      * {@inheritdoc}
      * Writes an array to a Ini string.
      */
-    public function toString($config, $pretty = true)
+    public function toString(array $config, bool $pretty = true): string
     {
         return $this->toINI($config);
     }
@@ -26,21 +26,17 @@ class Ini extends AbstractWriter
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedExtensions()
+    public static function getSupportedExtensions(): array
     {
         return ['ini'];
     }
 
     /**
      * Converts array to INI string.
-     * @param array $arr    Array to be converted
-     * @param array $parent Parent array
-     *
-     * @return string Converted array as INI
      *
      * @see https://stackoverflow.com/a/17317168/6523409/
      */
-    protected function toINI(array $arr, array $parent = [])
+    protected function toINI(array $arr, array $parent = []): string
     {
         $converted = '';
 

--- a/src/Writer/Json.php
+++ b/src/Writer/Json.php
@@ -21,7 +21,7 @@ class Json extends AbstractWriter
      * {@inheritdoc}
      * Writes an array to a JSON file.
      */
-    public function toFile($config, $filename)
+    public function toFile(array $config, string $filename): string
     {
         $data = $this->toString($config);
         $success = @file_put_contents($filename, $data.PHP_EOL);
@@ -36,7 +36,7 @@ class Json extends AbstractWriter
      * {@inheritdoc}
      * Writes an array to a JSON string.
      */
-    public function toString($config, $pretty = true)
+    public function toString(array $config, bool $pretty = true): string
     {
         return json_encode($config, $pretty ? (JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT) : 0);
     }
@@ -44,7 +44,7 @@ class Json extends AbstractWriter
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedExtensions()
+    public static function getSupportedExtensions(): array
     {
         return ['json'];
     }

--- a/src/Writer/Properties.php
+++ b/src/Writer/Properties.php
@@ -19,7 +19,7 @@ class Properties extends AbstractWriter
      * {@inheritdoc}
      * Writes an array to a Properties string.
      */
-    public function toString($config, $pretty = true)
+    public function toString(array $config, bool $pretty = true): string
     {
         return $this->toProperties($config);
     }
@@ -27,18 +27,15 @@ class Properties extends AbstractWriter
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedExtensions()
+    public static function getSupportedExtensions(): array
     {
         return ['properties'];
     }
 
     /**
      * Converts array to Properties string.
-     * @param array $arr    Array to be converted
-     *
-     * @return string Converted array as Properties
      */
-    protected function toProperties(array $arr)
+    protected function toProperties(array $arr): string
     {
         $converted = '';
 

--- a/src/Writer/Serialize.php
+++ b/src/Writer/Serialize.php
@@ -13,7 +13,7 @@ class Serialize extends AbstractWriter
     /**
      * {@inheritdoc}
      */
-    public function toString($config, $pretty = true)
+    public function toString(array $config, bool $pretty = true): string
     {
         return serialize($config);
     }
@@ -21,7 +21,7 @@ class Serialize extends AbstractWriter
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedExtensions()
+    public static function getSupportedExtensions(): array
     {
         return ['txt'];
     }

--- a/src/Writer/WriterInterface.php
+++ b/src/Writer/WriterInterface.php
@@ -20,29 +20,17 @@ interface WriterInterface
     /**
      * Writes a configuration from `$config` to `$filename`.
      *
-     * @param  array $config
-     * @param  string $filename
-     *
-     * @throws WriteException if the data could not be written to the file
-     *
-     * @return array
+     *@throws WriteException if the data could not be written to the file
      */
-    public function toFile($config, $filename);
+    public function toFile(array $config, string $filename): string;
 
     /**
      * Writes a configuration from `$config` to a string.
-     *
-     * @param  array $config
-     * @param  bool $pretty
-     *
-     * @return array
      */
-    public function toString($config, $pretty = true);
+    public function toString(array $config, bool $pretty = true): string;
 
     /**
      * Returns an array of allowed file extensions for this writer.
-     *
-     * @return array
      */
-    public static function getSupportedExtensions();
+    public static function getSupportedExtensions(): array;
 }

--- a/src/Writer/WriterInterface.php
+++ b/src/Writer/WriterInterface.php
@@ -20,7 +20,7 @@ interface WriterInterface
     /**
      * Writes a configuration from `$config` to `$filename`.
      *
-     *@throws WriteException if the data could not be written to the file
+     * @throws WriteException if the data could not be written to the file
      */
     public function toFile(array $config, string $filename): string;
 

--- a/src/Writer/Xml.php
+++ b/src/Writer/Xml.php
@@ -22,7 +22,7 @@ class Xml extends AbstractWriter
      * {@inheritdoc}
      * Writes an array to a Xml string.
      */
-    public function toString($config, $pretty = true)
+    public function toString(array $config, bool $pretty = true): string
     {
         $xml = $this->toXML($config);
         if ($pretty == false) {
@@ -40,22 +40,22 @@ class Xml extends AbstractWriter
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedExtensions()
+    public static function getSupportedExtensions(): array
     {
         return ['xml'];
     }
 
     /**
      * Converts array to XML string.
-     * @param array             $arr       Array to be converted
-     * @param string            $rootElement I specified will be taken as root element
-     * @param SimpleXMLElement  $xml         If specified content will be appended
+     * @param array                 $arr         Array to be converted
+     * @param string                $rootElement I specified will be taken as root element
+     * @param SimpleXMLElement|null $xml         If specified content will be appended
      *
-     * @return string Converted array as XML
+     * @return string|bool Converted array as XML
      *
      * @see https://www.kerstner.at/2011/12/php-array-to-xml-conversion/
      */
-    protected function toXML(array $arr, $rootElement = '<config/>', $xml = null)
+    protected function toXML(array $arr, string $rootElement = '<config/>', ?SimpleXMLElement $xml = null)
     {
         if ($xml === null) {
             $xml = new SimpleXMLElement($rootElement);

--- a/src/Writer/Xml.php
+++ b/src/Writer/Xml.php
@@ -25,7 +25,7 @@ class Xml extends AbstractWriter
     public function toString(array $config, bool $pretty = true): string
     {
         $xml = $this->toXML($config);
-        if ($pretty == false) {
+        if (!$pretty) {
             return $xml;
         }
 

--- a/src/Writer/Yaml.php
+++ b/src/Writer/Yaml.php
@@ -21,7 +21,7 @@ class Yaml extends AbstractWriter
      * {@inheritdoc}
      * Writes an array to a Yaml string.
      */
-    public function toString($config, $pretty = true)
+    public function toString(array $config, bool $pretty = true): string
     {
         return YamlParser::dump($config);
     }
@@ -29,7 +29,7 @@ class Yaml extends AbstractWriter
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedExtensions()
+    public static function getSupportedExtensions(): array
     {
         return ['yaml'];
     }

--- a/tests/AbstractConfigTest.php
+++ b/tests/AbstractConfigTest.php
@@ -2,6 +2,7 @@
 
 namespace Noodlehaus\Test;
 
+use Noodlehaus\ConfigInterface;
 use Noodlehaus\Test\Fixture\SimpleConfig;
 use PHPUnit\Framework\TestCase;
 
@@ -10,10 +11,7 @@ use PHPUnit\Framework\TestCase;
  */
 class AbstractConfigTest extends TestCase
 {
-    /**
-     * @var \Noodlehaus\Config
-     */
-    protected $config;
+    protected ConfigInterface $config;
 
     /**
      * Sets up the fixture, for example, opens a network connection.
@@ -44,7 +42,7 @@ class AbstractConfigTest extends TestCase
      * @covers \Noodlehaus\AbstractConfig::__construct()
      * @covers \Noodlehaus\AbstractConfig::getDefaults()
      */
-    public function testDefaultOptionsSetOnInstantiation()
+    public function testDefaultOptionsSetOnInstantiation(): void
     {
         $config = new SimpleConfig(
             [
@@ -59,7 +57,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::get()
      */
-    public function testGet()
+    public function testGet(): void
     {
         $this->assertSame('localhost', $this->config->get('host'));
     }
@@ -67,7 +65,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::get()
      */
-    public function testGetWithDefaultValue()
+    public function testGetWithDefaultValue(): void
     {
         $this->assertSame(128, $this->config->get('ttl', 128));
     }
@@ -75,7 +73,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::get()
      */
-    public function testGetNestedKey()
+    public function testGetNestedKey(): void
     {
         $this->assertSame('configuration', $this->config->get('application.name'));
     }
@@ -83,7 +81,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::get()
      */
-    public function testGetNestedKeyWithDefaultValue()
+    public function testGetNestedKeyWithDefaultValue(): void
     {
         $this->assertSame(128, $this->config->get('application.ttl', 128));
     }
@@ -91,7 +89,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::get()
      */
-    public function testGetNonexistentKey()
+    public function testGetNonexistentKey(): void
     {
         $this->assertNull($this->config->get('proxy'));
     }
@@ -99,7 +97,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::get()
      */
-    public function testGetNonexistentNestedKey()
+    public function testGetNonexistentNestedKey(): void
     {
         $this->assertNull($this->config->get('proxy.name'));
     }
@@ -107,7 +105,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::get()
      */
-    public function testGetReturnsArray()
+    public function testGetReturnsArray(): void
     {
         $this->assertArrayHasKey('name', $this->config->get('application'));
         $this->assertSame('configuration', $this->config->get('application.name'));
@@ -117,7 +115,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::set()
      */
-    public function testSet()
+    public function testSet(): void
     {
         $this->config->set('region', 'apac');
         $this->assertSame('apac', $this->config->get('region'));
@@ -126,7 +124,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::set()
      */
-    public function testSetNestedKey()
+    public function testSetNestedKey(): void
     {
         $this->config->set('location.country', 'Singapore');
         $this->assertSame('Singapore', $this->config->get('location.country'));
@@ -135,7 +133,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::set()
      */
-    public function testSetArray()
+    public function testSetArray(): void
     {
         $this->config->set('database', [
             'host' => 'localhost',
@@ -148,7 +146,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::set()
      */
-    public function testCacheWithNestedArray()
+    public function testCacheWithNestedArray(): void
     {
         $this->config->set('database', [
             'host' => 'localhost',
@@ -190,7 +188,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::set()
      */
-    public function testCacheWithNestedMiddleArray()
+    public function testCacheWithNestedMiddleArray(): void
     {
         $this->config->set('config', [
           'database' => [
@@ -214,7 +212,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::set()
      */
-    public function testSetAndUnsetArray()
+    public function testSetAndUnsetArray(): void
     {
         $this->config->set('database', [
             'host' => 'localhost',
@@ -231,7 +229,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::has()
      */
-    public function testHas()
+    public function testHas(): void
     {
         $this->assertTrue($this->config->has('application'));
         $this->assertTrue($this->config->has('user'));
@@ -241,7 +239,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::has()
      */
-    public function testHasNestedKey()
+    public function testHasNestedKey(): void
     {
         $this->assertTrue($this->config->has('application.name'));
         $this->assertTrue($this->config->has('application.runtime'));
@@ -252,7 +250,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::has()
      */
-    public function testHasCache()
+    public function testHasCache(): void
     {
         $this->assertTrue($this->config->has('application.name'));
         $this->assertTrue($this->config->has('application.name'));
@@ -261,7 +259,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::all()
      */
-    public function testAll()
+    public function testAll(): void
     {
         $all = [
             'host' => 'localhost',
@@ -284,7 +282,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::merge()
      */
-    public function testMerge()
+    public function testMerge(): void
     {
         $remote = new SimpleConfig(
             [
@@ -302,7 +300,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::offsetGet()
      */
-    public function testOffsetGet()
+    public function testOffsetGet(): void
     {
         $this->assertSame('localhost', $this->config['host']);
     }
@@ -310,7 +308,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::offsetGet()
      */
-    public function testOffsetGetNestedKey()
+    public function testOffsetGetNestedKey(): void
     {
         $this->assertSame('configuration', $this->config['application.name']);
     }
@@ -318,7 +316,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::offsetExists()
      */
-    public function testOffsetExists()
+    public function testOffsetExists(): void
     {
         $this->assertTrue(isset($this->config['host']));
     }
@@ -326,7 +324,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::offsetExists()
      */
-    public function testOffsetExistsReturnsFalseOnNonexistentKey()
+    public function testOffsetExistsReturnsFalseOnNonexistentKey(): void
     {
         $this->assertFalse(isset($this->config['database']));
     }
@@ -334,7 +332,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::offsetSet()
      */
-    public function testOffsetSet()
+    public function testOffsetSet(): void
     {
         $this->config['newkey'] = 'newvalue';
         $this->assertSame('newvalue', $this->config['newkey']);
@@ -343,7 +341,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::offsetUnset()
      */
-    public function testOffsetUnset()
+    public function testOffsetUnset(): void
     {
         unset($this->config['application']);
         $this->assertNull($this->config['application']);
@@ -352,7 +350,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::current()
      */
-    public function testCurrent()
+    public function testCurrent(): void
     {
         /* Reset to the beginning of the test config */
         $this->config->rewind();
@@ -376,7 +374,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::key()
      */
-    public function testKey()
+    public function testKey(): void
     {
         /* Reset to the beginning of the test config */
         $this->config->rewind();
@@ -400,7 +398,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::next()
      */
-    public function testNext()
+    public function testNext(): void
     {
         /* Reset to the beginning of the test config */
         $this->config->rewind();
@@ -418,7 +416,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::rewind()
      */
-    public function testRewind()
+    public function testRewind(): void
     {
         /* Rewind from somewhere out in the array */
         $this->config->next();
@@ -432,7 +430,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::valid()
      */
-    public function testValid()
+    public function testValid(): void
     {
         /* Reset to the beginning of the test config */
         $this->config->rewind();
@@ -463,7 +461,7 @@ class AbstractConfigTest extends TestCase
      * @covers \Noodlehaus\Config::valid()
      * @covers \Noodlehaus\Config::rewind()
      */
-    public function testIterator()
+    public function testIterator(): void
     {
         /* Create numerically indexed copies of the test config */
         $expectedKeys = ['host', 'port', 'servers', 'application', 'user'];
@@ -491,7 +489,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\Config::get()
      */
-    public function testGetShouldNotSet()
+    public function testGetShouldNotSet(): void
     {
         $this->config->get('invalid', 'default');
         $actual = $this->config->get('invalid', 'expected');
@@ -501,7 +499,7 @@ class AbstractConfigTest extends TestCase
     /**
      * @covers \Noodlehaus\AbstractConfig::remove()
      */
-    public function testRemove()
+    public function testRemove(): void
     {
         $this->config->remove('application');
         $this->assertNull($this->config['application']);

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -12,17 +12,14 @@ use PHPUnit\Framework\TestCase;
  */
 class ConfigTest extends TestCase
 {
-    /**
-     * @var Config
-     */
-    protected $config;
+    protected Config $config;
 
     /**
      * @covers Config::load()
      * @covers Config::loadFromFile()
      * @covers Config::getParser()
      */
-    public function testLoadWithUnsupportedFormat()
+    public function testLoadWithUnsupportedFormat(): void
     {
         $this->expectException(\Noodlehaus\Exception\UnsupportedFormatException::class);
         $this->expectExceptionMessage('Unsupported configuration format');
@@ -35,7 +32,7 @@ class ConfigTest extends TestCase
      * @covers Config::loadFromFile()
      * @covers Config::getParser()
      */
-    public function testConstructWithUnsupportedFormat()
+    public function testConstructWithUnsupportedFormat(): void
     {
         $this->expectException(\Noodlehaus\Exception\UnsupportedFormatException::class);
         $this->expectExceptionMessage('Unsupported configuration format');
@@ -49,7 +46,7 @@ class ConfigTest extends TestCase
      * @covers Config::getPathFromArray()
      * @covers Config::getValidPath()
      */
-    public function testConstructWithInvalidPath()
+    public function testConstructWithInvalidPath(): void
     {
         $this->expectException(\Noodlehaus\Exception\FileNotFoundException::class);
         $this->expectExceptionMessage('Configuration file: [ladadeedee] cannot be found');
@@ -63,7 +60,7 @@ class ConfigTest extends TestCase
      * @covers Config::getPathFromArray()
      * @covers Config::getValidPath()
      */
-    public function testConstructWithEmptyDirectory()
+    public function testConstructWithEmptyDirectory(): void
     {
         $this->expectException(\Noodlehaus\Exception\EmptyDirectoryException::class);
         $config = new Config(__DIR__ . '/mocks/empty');
@@ -76,7 +73,7 @@ class ConfigTest extends TestCase
      * @covers Config::getPathFromArray()
      * @covers Config::getValidPath()
      */
-    public function testConstructWithArray()
+    public function testConstructWithArray(): void
     {
         $paths = [__DIR__ . '/mocks/pass/config.xml', __DIR__ . '/mocks/pass/config2.json'];
         $config = new Config($paths);
@@ -94,7 +91,7 @@ class ConfigTest extends TestCase
      * @covers Config::getPathFromArray()
      * @covers Config::getValidPath()
      */
-    public function testConstructWithArrayWithNonexistentFile()
+    public function testConstructWithArrayWithNonexistentFile(): void
     {
         $this->expectException(\Noodlehaus\Exception\FileNotFoundException::class);
         $paths = [__DIR__ . '/mocks/pass/config.xml', __DIR__ . '/mocks/pass/config3.json'];
@@ -113,7 +110,7 @@ class ConfigTest extends TestCase
      * @covers Config::getPathFromArray()
      * @covers Config::getValidPath()
      */
-    public function testConstructWithArrayWithOptionalFile()
+    public function testConstructWithArrayWithOptionalFile(): void
     {
         $paths = [__DIR__ . '/mocks/pass/config.xml', '?' . __DIR__ . '/mocks/pass/config2.json'];
         $config = new Config($paths);
@@ -131,7 +128,7 @@ class ConfigTest extends TestCase
      * @covers Config::getPathFromArray()
      * @covers Config::getValidPath()
      */
-    public function testConstructWithArrayWithOptionalNonexistentFile()
+    public function testConstructWithArrayWithOptionalNonexistentFile(): void
     {
         $paths = [__DIR__ . '/mocks/pass/config.xml', '?' . __DIR__ . '/mocks/pass/config3.json'];
         $config = new Config($paths);
@@ -149,7 +146,7 @@ class ConfigTest extends TestCase
      * @covers Config::getPathFromArray()
      * @covers Config::getValidPath()
      */
-    public function testConstructWithDirectory()
+    public function testConstructWithDirectory(): void
     {
         $config = new Config(__DIR__ . '/mocks/dir');
 
@@ -166,7 +163,7 @@ class ConfigTest extends TestCase
      * @covers Config::getPathFromArray()
      * @covers Config::getValidPath()
      */
-    public function testConstructWithYml()
+    public function testConstructWithYml(): void
     {
         $config = new Config(__DIR__ . '/mocks/pass/config.yml');
 
@@ -183,7 +180,7 @@ class ConfigTest extends TestCase
      * @covers Config::getPathFromArray()
      * @covers Config::getValidPath()
      */
-    public function testConstructWithYmlDist()
+    public function testConstructWithYmlDist(): void
     {
         $config = new Config(__DIR__ . '/mocks/pass/config.yml.dist');
 
@@ -200,7 +197,7 @@ class ConfigTest extends TestCase
      * @covers Config::getPathFromArray()
      * @covers Config::getValidPath()
      */
-    public function testConstructWithEmptyYml()
+    public function testConstructWithEmptyYml(): void
     {
         $config = new Config(__DIR__ . '/mocks/pass/empty.yaml');
 
@@ -216,7 +213,7 @@ class ConfigTest extends TestCase
      * @covers Config::getPathFromArray()
      * @covers Config::getValidPath()
      */
-    public function testConstructWithFileParser()
+    public function testConstructWithFileParser(): void
     {
         $config = new Config(__DIR__ . '/mocks/pass/json.config', new JsonParser());
 
@@ -230,7 +227,7 @@ class ConfigTest extends TestCase
      * @covers Config::__construct()
      * @covers Config::loadFromString()
      */
-    public function testConstructWithStringParser()
+    public function testConstructWithStringParser(): void
     {
         $settings = file_get_contents(__DIR__ . '/mocks/pass/config.php');
         $config = new Config($settings, new \Noodlehaus\Parser\Php, true);
@@ -246,7 +243,7 @@ class ConfigTest extends TestCase
      * @covers Config::get()
      * @dataProvider specialConfigProvider()
      */
-    public function testGetReturnsArrayMergedArray($config)
+    public function testGetReturnsArrayMergedArray($config): void
     {
         $this->assertCount(4, $config->get('servers'));
     }
@@ -255,7 +252,7 @@ class ConfigTest extends TestCase
      * @covers Config::toFile()
      * @covers Config::getWriter()
      */
-    public function testWritesToFile()
+    public function testWritesToFile(): void
     {
         $config = new Config(json_encode(['foo' => 'bar']), new JsonParser(), true);
         $filename = tempnam(sys_get_temp_dir(), 'config').'.json';
@@ -268,7 +265,7 @@ class ConfigTest extends TestCase
     /**
      * @covers Config::toString()
      */
-    public function testWritesToString()
+    public function testWritesToString(): void
     {
         $config = new Config(json_encode(['foo' => 'bar']), new JsonParser(), true);
 
@@ -280,7 +277,7 @@ class ConfigTest extends TestCase
     /**
      * Provides names of example configuration files
      */
-    public function configProvider()
+    public function configProvider(): array
     {
         return array_merge(
             [
@@ -297,7 +294,7 @@ class ConfigTest extends TestCase
     /**
      * Provides names of example configuration files (for array and directory)
      */
-    public function specialConfigProvider()
+    public function specialConfigProvider(): array
     {
         return [
             [

--- a/tests/Fixture/SimpleConfig.php
+++ b/tests/Fixture/SimpleConfig.php
@@ -6,7 +6,7 @@ use Noodlehaus\AbstractConfig;
 
 class SimpleConfig extends AbstractConfig
 {
-    protected function getDefaults()
+    protected function getDefaults(): array
     {
         return [
             'host' => 'localhost',

--- a/tests/Parser/IniTest.php
+++ b/tests/Parser/IniTest.php
@@ -10,10 +10,7 @@ use PHPUnit\Framework\TestCase;
  */
 class IniTest extends TestCase
 {
-    /**
-     * @var Ini
-     */
-    protected $ini;
+    protected Ini $ini;
 
     /**
      * Sets up the fixture, for example, opens a network connection.
@@ -27,7 +24,7 @@ class IniTest extends TestCase
     /**
      * @covers \Noodlehaus\Parser\Ini::getSupportedExtensions()
      */
-    public function testGetSupportedExtensions()
+    public function testGetSupportedExtensions(): void
     {
         $expected = ['ini'];
         $actual   = $this->ini->getSupportedExtensions();
@@ -40,7 +37,7 @@ class IniTest extends TestCase
      * Tests the case where an INI string contains no parsable data at all, resulting in parse_ini_string
      * returning NULL, but not setting an error retrievable by error_get_last()
      */
-    public function testLoadInvalidIniGBH()
+    public function testLoadInvalidIniGBH(): void
     {
         $this->expectException(\Noodlehaus\Exception\ParseException::class);
         $this->expectExceptionMessage('No parsable content');
@@ -51,7 +48,7 @@ class IniTest extends TestCase
      * @covers \Noodlehaus\Parser\Ini::parseString()
      * @covers \Noodlehaus\Parser\Ini::parse()
      */
-    public function testLoadInvalidIni()
+    public function testLoadInvalidIni(): void
     {
         if (PHP_VERSION_ID < 70400 && PHP_VERSION_ID >= 50500) {
             $exceptionMessage = "syntax error, unexpected \$end, expecting ']'";
@@ -70,7 +67,7 @@ class IniTest extends TestCase
      * @covers \Noodlehaus\Parser\Ini::parseString()
      * @covers \Noodlehaus\Parser\Ini::parse()
      */
-    public function testLoadIni()
+    public function testLoadIni(): void
     {
         $file = $this->ini->parseFile(__DIR__ . '/../mocks/pass/config.ini');
         $string = $this->ini->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config.ini'));
@@ -88,7 +85,7 @@ class IniTest extends TestCase
      * @covers \Noodlehaus\Parser\Ini::parse()
      * @covers \Noodlehaus\Parser\Ini::expandDottedKey()
      */
-    public function testLoadIniWithDottedName()
+    public function testLoadIniWithDottedName(): void
     {
         $file = $this->ini->parseFile(__DIR__ . '/../mocks/pass/config2.ini');
         $string = $this->ini->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config2.ini'));

--- a/tests/Parser/JsonTest.php
+++ b/tests/Parser/JsonTest.php
@@ -10,10 +10,7 @@ use PHPUnit\Framework\TestCase;
  */
 class JsonTest extends TestCase
 {
-    /**
-     * @var Json
-     */
-    protected $json;
+    protected Json $json;
 
     /**
      * Sets up the fixture, for example, opens a network connection.
@@ -27,7 +24,7 @@ class JsonTest extends TestCase
     /**
      * @covers \Noodlehaus\Parser\Json::getSupportedExtensions()
      */
-    public function testGetSupportedExtensions()
+    public function testGetSupportedExtensions(): void
     {
         $expected = ['json'];
         $actual   = $this->json->getSupportedExtensions();
@@ -38,7 +35,7 @@ class JsonTest extends TestCase
      * @covers \Noodlehaus\Parser\Json::parseFile()
      * @covers \Noodlehaus\Parser\Json::parse()
      */
-    public function testLoadInvalidJson()
+    public function testLoadInvalidJson(): void
     {
         $this->expectException(\Noodlehaus\Exception\ParseException::class);
         $this->expectExceptionMessage('Syntax error');
@@ -50,7 +47,7 @@ class JsonTest extends TestCase
      * @covers \Noodlehaus\Parser\Json::parseString()
      * @covers \Noodlehaus\Parser\Json::parse()
      */
-    public function testLoadJson()
+    public function testLoadJson(): void
     {
         $file = $this->json->parseFile(__DIR__ . '/../mocks/pass/config.json');
         $string = $this->json->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config.json'));

--- a/tests/Parser/PhpTest.php
+++ b/tests/Parser/PhpTest.php
@@ -10,10 +10,7 @@ use PHPUnit\Framework\TestCase;
  */
 class PhpTest extends TestCase
 {
-    /**
-     * @var Php
-     */
-    protected $php;
+    protected Php $php;
 
     /**
      * Sets up the fixture, for example, opens a network connection.
@@ -27,7 +24,7 @@ class PhpTest extends TestCase
     /**
      * @covers \Noodlehaus\Parser\Php::getSupportedExtensions()
      */
-    public function testGetSupportedExtensions()
+    public function testGetSupportedExtensions(): void
     {
         $expected = ['php'];
         $actual   = $this->php->getSupportedExtensions();
@@ -38,7 +35,7 @@ class PhpTest extends TestCase
      * @covers \Noodlehaus\Parser\Php::parseFile()
      * @covers \Noodlehaus\Parser\Php::parse()
      */
-    public function testLoadInvalidPhp()
+    public function testLoadInvalidPhp(): void
     {
         $this->expectException(\Noodlehaus\Exception\UnsupportedFormatException::class);
         $this->expectExceptionMessage('PHP data does not return an array');
@@ -48,7 +45,7 @@ class PhpTest extends TestCase
     /**
      * @covers \Noodlehaus\Parser\Php::parseFile()
      */
-    public function testLoadExceptionalPhpFile()
+    public function testLoadExceptionalPhpFile(): void
     {
         $this->expectException(\Noodlehaus\Exception\ParseException::class);
         $this->expectExceptionMessage('PHP file threw an exception');
@@ -59,7 +56,7 @@ class PhpTest extends TestCase
      * @covers \Noodlehaus\Parser\Php::parseString()
      * @covers \Noodlehaus\Parser\Php::isolate()
      */
-    public function testLoadExceptionalPhpString()
+    public function testLoadExceptionalPhpString(): void
     {
         $this->expectException(\Noodlehaus\Exception\ParseException::class);
         $this->expectExceptionMessage('PHP string threw an exception');
@@ -72,7 +69,7 @@ class PhpTest extends TestCase
      * @covers \Noodlehaus\Parser\Php::isolate()
      * @covers \Noodlehaus\Parser\Php::parse()
      */
-    public function testLoadPhpArray()
+    public function testLoadPhpArray(): void
     {
         $file = $this->php->parseFile(__DIR__ . '/../mocks/pass/config.php');
         $string = $this->php->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config.php'));
@@ -90,7 +87,7 @@ class PhpTest extends TestCase
      * @covers \Noodlehaus\Parser\Php::isolate()
      * @covers \Noodlehaus\Parser\Php::parse()
      */
-    public function testLoadPhpCallable()
+    public function testLoadPhpCallable(): void
     {
         $file = $this->php->parseFile(__DIR__ . '/../mocks/pass/config-exec.php');
         $string = $this->php->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config-exec.php'));
@@ -108,7 +105,7 @@ class PhpTest extends TestCase
      * @covers \Noodlehaus\Parser\Php::isolate()
      * @covers \Noodlehaus\Parser\Php::parse()
      */
-    public function testLoadPhpVariable()
+    public function testLoadPhpVariable(): void
     {
         $file = $this->php->parseFile(__DIR__ . '/../mocks/pass/config-var.php');
         $string = $this->php->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config-var.php'));

--- a/tests/Parser/PropertiesTest.php
+++ b/tests/Parser/PropertiesTest.php
@@ -7,10 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class PropertiesTest extends TestCase
 {
-    /**
-     * @var Properties
-     */
-    protected $properties;
+    protected Properties $properties;
 
     /**
      * Sets up the fixture, for example, opens a network connection.
@@ -24,7 +21,7 @@ class PropertiesTest extends TestCase
     /**
      * @covers \Noodlehaus\Parser\Properties::getSupportedExtensions()
      */
-    public function testGetSupportedExtensions()
+    public function testGetSupportedExtensions(): void
     {
         $expected = ['properties'];
         $actual = $this->properties->getSupportedExtensions();
@@ -36,7 +33,7 @@ class PropertiesTest extends TestCase
      * @covers \Noodlehaus\Parser\Properties::parseString()
      * @covers \Noodlehaus\Parser\Properties::parse()
      */
-    public function testLoadProperties()
+    public function testLoadProperties(): void
     {
         $config = $this->properties->parseFile(__DIR__.'/../mocks/pass/config.properties');
 
@@ -53,7 +50,7 @@ class PropertiesTest extends TestCase
      * @covers \Noodlehaus\Parser\Ini::parseFile()
      * @covers \Noodlehaus\Parser\Ini::parse()
      */
-    public function testLoadInvalidIniGBH()
+    public function testLoadInvalidIniGBH(): void
     {
         $config = $this->properties->parseFile(__DIR__.'/../mocks/fail/error.properties');
 

--- a/tests/Parser/SerializeTest.php
+++ b/tests/Parser/SerializeTest.php
@@ -10,10 +10,7 @@ use PHPUnit\Framework\TestCase;
  */
 class SerializeTest extends TestCase
 {
-    /**
-     * @var Serialize
-     */
-    protected $serialize;
+    protected Serialize $serialize;
 
     /**
      * Sets up the fixture, for example, opens a network connection.
@@ -27,7 +24,7 @@ class SerializeTest extends TestCase
     /**
      * @covers \Noodlehaus\Parser\Serialize::getSupportedExtensions()
      */
-    public function testGetSupportedExtensions()
+    public function testGetSupportedExtensions(): void
     {
         $expected = ['txt'];
         $actual   = $this->serialize->getSupportedExtensions();
@@ -38,7 +35,7 @@ class SerializeTest extends TestCase
      * @covers \Noodlehaus\Parser\Serialize::parseFile()
      * @covers \Noodlehaus\Parser\Serialize::parse()
      */
-    public function testLoadInvalidSerialize()
+    public function testLoadInvalidSerialize(): void
     {
         $this->expectException(\Noodlehaus\Exception\ParseException::class);
         $this->expectExceptionMessage('unserialize(): Error at offset 57 of 58 bytes');
@@ -50,7 +47,7 @@ class SerializeTest extends TestCase
      * @covers \Noodlehaus\Parser\Serialize::parseString()
      * @covers \Noodlehaus\Parser\Serialize::parse()
      */
-    public function testLoadSerialize()
+    public function testLoadSerialize(): void
     {
         $file = $this->serialize->parseFile(__DIR__ . '/../mocks/pass/config.txt');
         $string = $this->serialize->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config.txt'));

--- a/tests/Parser/XmlTest.php
+++ b/tests/Parser/XmlTest.php
@@ -10,10 +10,7 @@ use PHPUnit\Framework\TestCase;
  */
 class XmlTest extends TestCase
 {
-    /**
-     * @var Xml
-     */
-    protected $xml;
+    protected Xml $xml;
 
     /**
      * Sets up the fixture, for example, opens a network connection.
@@ -27,7 +24,7 @@ class XmlTest extends TestCase
     /**
      * @covers \Noodlehaus\Parser\Xml::getSupportedExtensions()
      */
-    public function testGetSupportedExtensions()
+    public function testGetSupportedExtensions(): void
     {
         $expected = ['xml'];
         $actual   = $this->xml->getSupportedExtensions();
@@ -38,7 +35,7 @@ class XmlTest extends TestCase
      * @covers \Noodlehaus\Parser\Xml::parseFile()
      * @covers \Noodlehaus\Parser\Xml::parse()
      */
-    public function testLoadInvalidXml()
+    public function testLoadInvalidXml(): void
     {
         $this->expectException(\Noodlehaus\Exception\ParseException::class);
         $this->expectExceptionMessage('Opening and ending tag mismatch: name line 4');
@@ -50,7 +47,7 @@ class XmlTest extends TestCase
      * @covers \Noodlehaus\Parser\Xml::parseString()
      * @covers \Noodlehaus\Parser\Xml::parse()
      */
-    public function testLoadXml()
+    public function testLoadXml(): void
     {
         $file = $this->xml->parseFile(__DIR__ . '/../mocks/pass/config.xml');
         $string = $this->xml->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config.xml'));

--- a/tests/Parser/YamlTest.php
+++ b/tests/Parser/YamlTest.php
@@ -10,10 +10,7 @@ use PHPUnit\Framework\TestCase;
  */
 class YamlTest extends TestCase
 {
-    /**
-     * @var Yaml
-     */
-    protected $yaml;
+    protected Yaml $yaml;
 
     /**
      * Sets up the fixture, for example, opens a network connection.
@@ -27,7 +24,7 @@ class YamlTest extends TestCase
     /**
      * @covers \Noodlehaus\Parser\Yaml::getSupportedExtensions()
      */
-    public function testGetSupportedExtensions()
+    public function testGetSupportedExtensions(): void
     {
         $expected = ['yaml', 'yml'];
         $actual   = $this->yaml->getSupportedExtensions();
@@ -38,7 +35,7 @@ class YamlTest extends TestCase
      * @covers \Noodlehaus\Parser\Yaml::parseFile()
      * @covers \Noodlehaus\Parser\Yaml::parse()
      */
-    public function testLoadInvalidYamlFile()
+    public function testLoadInvalidYamlFile(): void
     {
         $this->expectException(\Noodlehaus\Exception\ParseException::class);
         $this->expectExceptionMessage('Error parsing YAML file');
@@ -49,7 +46,7 @@ class YamlTest extends TestCase
      * @covers \Noodlehaus\Parser\Yaml::parseString()
      * @covers \Noodlehaus\Parser\Yaml::parse()
      */
-    public function testLoadInvalidYamlString()
+    public function testLoadInvalidYamlString(): void
     {
         $this->expectException(\Noodlehaus\Exception\ParseException::class);
         $this->expectExceptionMessage('Error parsing YAML string');
@@ -60,7 +57,7 @@ class YamlTest extends TestCase
      * @covers \Noodlehaus\Parser\Yaml::parseFile()
      * @covers \Noodlehaus\Parser\Yaml::parse()
      */
-    public function testLoadYaml()
+    public function testLoadYaml(): void
     {
         $actual = $this->yaml->parseFile(__DIR__ . '/../mocks/pass/config.yaml');
         $this->assertSame('localhost', $actual['host']);
@@ -70,7 +67,7 @@ class YamlTest extends TestCase
     /**
      * @covers \Noodlehaus\Parser\Yaml::parse()
      */
-    public function testLoadYml()
+    public function testLoadYml(): void
     {
         $actual = $this->yaml->parseFile(__DIR__ . '/../mocks/pass/config.yml');
         $this->assertSame('localhost', $actual['host']);
@@ -80,7 +77,7 @@ class YamlTest extends TestCase
     /**
      * @covers \Noodlehaus\Parser\Yaml::parseString()
      */
-    public function testLoadYamlString()
+    public function testLoadYamlString(): void
     {
         $actual = $this->yaml->parseString(file_get_contents(__DIR__ . '/../mocks/pass/config.yaml'));
         $this->assertSame('localhost', $actual['host']);

--- a/tests/Writer/IniTest.php
+++ b/tests/Writer/IniTest.php
@@ -37,7 +37,7 @@ class IniTest extends TestCase
      * Tears down the fixture, for example, closes a network connection.
      * This method is called after a test is executed.
      */
-    protected function tear_down()
+    protected function tearDown(): void
     {
         unlink($this->temp_file);
     }

--- a/tests/Writer/IniTest.php
+++ b/tests/Writer/IniTest.php
@@ -7,20 +7,11 @@ use PHPUnit\Framework\TestCase;
 
 class IniTest extends TestCase
 {
-    /**
-     * @var Ini
-     */
-    protected $writer;
+    protected Ini $writer;
 
-    /**
-     * @var string
-     */
-    protected $temp_file;
+    protected string $temp_file;
 
-    /**
-     * @var array
-     */
-    protected $data;
+    protected array $data;
 
     /**
      * Sets up the fixture, for example, opens a network connection.
@@ -54,7 +45,7 @@ class IniTest extends TestCase
     /**
      * @covers \Noodlehaus\Writer\Ini::getSupportedExtensions()
      */
-    public function testGetSupportedExtensions()
+    public function testGetSupportedExtensions(): void
     {
         $expected = ['ini'];
         $actual = $this->writer->getSupportedExtensions();
@@ -65,7 +56,7 @@ class IniTest extends TestCase
      * @covers \Noodlehaus\Writer\Ini::toString()
      * @covers \Noodlehaus\Writer\Ini::toINI()
      */
-    public function testEncodeIni()
+    public function testEncodeIni(): void
     {
         $actual = $this->writer->toString($this->data);
         $expected = <<< 'EOD'
@@ -85,7 +76,7 @@ EOD;
      * @covers \Noodlehaus\Writer\Ini::toFile()
      * @covers \Noodlehaus\Writer\Ini::toINI()
      */
-    public function testWriteIni()
+    public function testWriteIni(): void
     {
         $this->writer->toFile($this->data, $this->temp_file);
 
@@ -98,7 +89,7 @@ EOD;
      * @covers \Noodlehaus\Writer\Ini::toFile()
      * @covers \Noodlehaus\Writer\Ini::toINI()
      */
-    public function testUnwritableFile()
+    public function testUnwritableFile(): void
     {
         $this->expectException(\Noodlehaus\Exception\WriteException::class);
         $this->expectExceptionMessage('There was an error writing the file');

--- a/tests/Writer/JsonTest.php
+++ b/tests/Writer/JsonTest.php
@@ -40,7 +40,7 @@ class JsonTest extends TestCase
      * Tears down the fixture, for example, closes a network connection.
      * This method is called after a test is executed.
      */
-    protected function tear_down()
+    protected function tearDown(): void
     {
         unlink($this->temp_file);
     }

--- a/tests/Writer/JsonTest.php
+++ b/tests/Writer/JsonTest.php
@@ -7,20 +7,11 @@ use PHPUnit\Framework\TestCase;
 
 class JsonTest extends TestCase
 {
-    /**
-     * @var Json
-     */
-    protected $writer;
+    protected Json $writer;
 
-    /**
-     * @var string
-     */
-    protected $temp_file;
+    protected string $temp_file;
 
-    /**
-     * @var array
-     */
-    protected $data;
+    protected array $data;
 
     /**
      * Sets up the fixture, for example, opens a network connection.
@@ -57,7 +48,7 @@ class JsonTest extends TestCase
     /**
      * @covers \Noodlehaus\Writer\Json::getSupportedExtensions()
      */
-    public function testGetSupportedExtensions()
+    public function testGetSupportedExtensions(): void
     {
         $expected = ['json'];
         $actual = $this->writer->getSupportedExtensions();
@@ -67,7 +58,7 @@ class JsonTest extends TestCase
     /**
      * @covers \Noodlehaus\Writer\Json::toString()
      */
-    public function testEncodeJson()
+    public function testEncodeJson(): void
     {
         $actual = $this->writer->toString($this->data, false);
         $expected = '{"application":{"name":"configuration","secret":"s3cr3t"},"host":"localhost","port":80,"servers":["host1","host2","host3"]}';
@@ -79,7 +70,7 @@ class JsonTest extends TestCase
      * @covers \Noodlehaus\Writer\Json::toString()
      * @covers \Noodlehaus\Writer\Json::toFile()
      */
-    public function testWriteJson()
+    public function testWriteJson(): void
     {
         $this->writer->toFile($this->data, $this->temp_file);
 
@@ -91,7 +82,7 @@ class JsonTest extends TestCase
      * @covers \Noodlehaus\Writer\Json::toString()
      * @covers \Noodlehaus\Writer\Json::toFile()
      */
-    public function testUnwritableFile()
+    public function testUnwritableFile(): void
     {
         $this->expectException(\Noodlehaus\Exception\WriteException::class);
         $this->expectExceptionMessage('There was an error writing the file');

--- a/tests/Writer/PropertiesTest.php
+++ b/tests/Writer/PropertiesTest.php
@@ -36,7 +36,7 @@ class PropertiesTest extends TestCase
      * Tears down the fixture, for example, closes a network connection.
      * This method is called after a test is executed.
      */
-    protected function tear_down()
+    protected function tearDown(): void
     {
         unlink($this->temp_file);
     }

--- a/tests/Writer/PropertiesTest.php
+++ b/tests/Writer/PropertiesTest.php
@@ -7,20 +7,11 @@ use PHPUnit\Framework\TestCase;
 
 class PropertiesTest extends TestCase
 {
-    /**
-     * @var Properties
-     */
-    protected $writer;
+    protected Properties $writer;
 
-    /**
-     * @var string
-     */
-    protected $temp_file;
+    protected string $temp_file;
 
-    /**
-     * @var array
-     */
-    protected $data;
+    protected array $data;
 
     /**
      * Sets up the fixture, for example, opens a network connection.
@@ -53,7 +44,7 @@ class PropertiesTest extends TestCase
     /**
      * @covers \Noodlehaus\Writer\Properties::getSupportedExtensions()
      */
-    public function testGetSupportedExtensions()
+    public function testGetSupportedExtensions(): void
     {
         $expected = ['properties'];
         $actual = $this->writer->getSupportedExtensions();
@@ -64,7 +55,7 @@ class PropertiesTest extends TestCase
      * @covers \Noodlehaus\Writer\Properties::toString()
      * @covers \Noodlehaus\Writer\Properties::toProperties()
      */
-    public function testEncodeProperties()
+    public function testEncodeProperties(): void
     {
         $actual = $this->writer->toString($this->data);
         $expected = <<< 'EOD'
@@ -86,7 +77,7 @@ EOD;
      * @covers \Noodlehaus\Writer\Properties::toFile()
      * @covers \Noodlehaus\Writer\Properties::toProperties()
      */
-    public function testWriteProperties()
+    public function testWriteProperties(): void
     {
         $this->writer->toFile($this->data, $this->temp_file);
 
@@ -99,7 +90,7 @@ EOD;
      * @covers \Noodlehaus\Writer\Properties::toFile()
      * @covers \Noodlehaus\Writer\Properties::toProperties()
      */
-    public function testUnwritableFile()
+    public function testUnwritableFile(): void
     {
         $this->expectException(\Noodlehaus\Exception\WriteException::class);
         $this->expectExceptionMessage('There was an error writing the file');

--- a/tests/Writer/SerializeTest.php
+++ b/tests/Writer/SerializeTest.php
@@ -7,20 +7,11 @@ use PHPUnit\Framework\TestCase;
 
 class SerializeTest extends TestCase
 {
-    /**
-     * @var Serialize
-     */
-    protected $writer;
+    protected Serialize $writer;
 
-    /**
-     * @var string
-     */
-    protected $temp_file;
+    protected string $temp_file;
 
-    /**
-     * @var array
-     */
-    protected $data;
+    protected array $data;
 
     /**
      * Sets up the fixture, for example, opens a network connection.
@@ -57,7 +48,7 @@ class SerializeTest extends TestCase
     /**
      * @covers \Noodlehaus\Writer\Serialize::getSupportedExtensions()
      */
-    public function testGetSupportedExtensions()
+    public function testGetSupportedExtensions(): void
     {
         $expected = ['txt'];
         $actual = $this->writer->getSupportedExtensions();
@@ -67,7 +58,7 @@ class SerializeTest extends TestCase
     /**
      * @covers \Noodlehaus\Writer\Serialize::toString()
      */
-    public function testSerialize()
+    public function testSerialize(): void
     {
         $actual = $this->writer->toString($this->data, false);
         $expected = 'a:4:{s:11:"application";a:2:{s:4:"name";s:13:"configuration";s:6:"secret";s:6:"s3cr3t";}s:4:"host";s:9:"localhost";s:4:"port";i:80;s:7:"servers";a:3:{i:0;s:5:"host1";i:1;s:5:"host2";i:2;s:5:"host3";}}';
@@ -79,7 +70,7 @@ class SerializeTest extends TestCase
      * @covers \Noodlehaus\Writer\Serialize::toString()
      * @covers \Noodlehaus\Writer\Serialize::toFile()
      */
-    public function testWriteSerialize()
+    public function testWriteSerialize(): void
     {
         $this->writer->toFile($this->data, $this->temp_file);
 
@@ -91,7 +82,7 @@ class SerializeTest extends TestCase
      * @covers \Noodlehaus\Writer\Serialize::toString()
      * @covers \Noodlehaus\Writer\Serialize::toFile()
      */
-    public function testUnwritableFile()
+    public function testUnwritableFile(): void
     {
         $this->expectException(\Noodlehaus\Exception\WriteException::class);
         $this->expectExceptionMessage('There was an error writing the file');

--- a/tests/Writer/SerializeTest.php
+++ b/tests/Writer/SerializeTest.php
@@ -40,7 +40,7 @@ class SerializeTest extends TestCase
      * Tears down the fixture, for example, closes a network connection.
      * This method is called after a test is executed.
      */
-    protected function tear_down()
+    protected function tearDown(): void
     {
         unlink($this->temp_file);
     }

--- a/tests/Writer/XmlTest.php
+++ b/tests/Writer/XmlTest.php
@@ -40,7 +40,7 @@ class XmlTest extends TestCase
      * Tears down the fixture, for example, closes a network connection.
      * This method is called after a test is executed.
      */
-    protected function tear_down()
+    protected function tearDown(): void
     {
         // unlink($this->temp_file);
     }

--- a/tests/Writer/XmlTest.php
+++ b/tests/Writer/XmlTest.php
@@ -7,20 +7,11 @@ use PHPUnit\Framework\TestCase;
 
 class XmlTest extends TestCase
 {
-    /**
-     * @var Xml
-     */
-    protected $writer;
+    protected Xml $writer;
 
-    /**
-     * @var string
-     */
-    protected $temp_file;
+    protected string $temp_file;
 
-    /**
-     * @var array
-     */
-    protected $data;
+    protected array $data;
 
     /**
      * Sets up the fixture, for example, opens a network connection.
@@ -57,7 +48,7 @@ class XmlTest extends TestCase
     /**
      * @covers \Noodlehaus\Writer\Xml::getSupportedExtensions()
      */
-    public function testGetSupportedExtensions()
+    public function testGetSupportedExtensions(): void
     {
         $expected = ['xml'];
         $actual = $this->writer->getSupportedExtensions();
@@ -68,7 +59,7 @@ class XmlTest extends TestCase
      * @covers \Noodlehaus\Writer\Xml::toString()
      * @covers \Noodlehaus\Writer\Xml::toXML()
      */
-    public function testEncodeXml()
+    public function testEncodeXml(): void
     {
         $actual = $this->writer->toString($this->data, false);
         $expected = <<<'EOD'
@@ -84,7 +75,7 @@ EOD;
      * @covers \Noodlehaus\Writer\Xml::toString()
      * @covers \Noodlehaus\Writer\Xml::toXML()
      */
-    public function testWriteXml()
+    public function testWriteXml(): void
     {
         $this->writer->toFile($this->data, $this->temp_file);
 
@@ -96,7 +87,7 @@ EOD;
      * @covers \Noodlehaus\Writer\Xml::toFile()
      * @covers \Noodlehaus\Writer\Xml::toXML()
      */
-    public function testUnwritableFile()
+    public function testUnwritableFile(): void
     {
         $this->expectException(\Noodlehaus\Exception\WriteException::class);
         $this->expectExceptionMessage('There was an error writing the file');

--- a/tests/Writer/YamlTest.php
+++ b/tests/Writer/YamlTest.php
@@ -7,20 +7,11 @@ use PHPUnit\Framework\TestCase;
 
 class YamlTest extends TestCase
 {
-    /**
-     * @var Yaml
-     */
-    protected $writer;
+    protected Yaml $writer;
 
-    /**
-     * @var string
-     */
-    protected $temp_file;
+    protected string $temp_file;
 
-    /**
-     * @var array
-     */
-    protected $data;
+    protected array $data;
 
     /**
      * Sets up the fixture, for example, opens a network connection.
@@ -57,7 +48,7 @@ class YamlTest extends TestCase
     /**
      * @covers \Noodlehaus\Writer\Yaml::getSupportedExtensions()
      */
-    public function testGetSupportedExtensions()
+    public function testGetSupportedExtensions(): void
     {
         $expected = ['yaml'];
         $actual = $this->writer->getSupportedExtensions();
@@ -67,7 +58,7 @@ class YamlTest extends TestCase
     /**
      * @covers \Noodlehaus\Writer\Yaml::toString()
      */
-    public function testEncodeYaml()
+    public function testEncodeYaml(): void
     {
         $actual = $this->writer->toString($this->data);
         $expected = <<<'EOD'
@@ -89,7 +80,7 @@ EOD;
      * @covers \Noodlehaus\Writer\Yaml::toString()
      * @covers \Noodlehaus\Writer\Yaml::toFile()
      */
-    public function testWriteYaml()
+    public function testWriteYaml(): void
     {
         $this->writer->toFile($this->data, $this->temp_file);
         $this->assertFileExists($this->temp_file);
@@ -100,7 +91,7 @@ EOD;
      * @covers \Noodlehaus\Writer\Yaml::toString()
      * @covers \Noodlehaus\Writer\Yaml::toFile()
      */
-    public function testUnwritableFile()
+    public function testUnwritableFile(): void
     {
         $this->expectException(\Noodlehaus\Exception\WriteException::class);
         $this->expectExceptionMessage('There was an error writing the file');

--- a/tests/Writer/YamlTest.php
+++ b/tests/Writer/YamlTest.php
@@ -40,7 +40,7 @@ class YamlTest extends TestCase
      * Tears down the fixture, for example, closes a network connection.
      * This method is called after a test is executed.
      */
-    protected function tear_down()
+    protected function tearDown(): void
     {
         unlink($this->temp_file);
     }


### PR DESCRIPTION
This PR;

- adds PHP native types to methods, properties, and method parameters where possible,
- corrects some type declarations,
- corrects PHPUnit tear down method name (renames from `tear_down` to `tearDown`),
- modernizes/simplifies some expressions.